### PR TITLE
Prevent lable duplication on pull-to-refesh

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
@@ -60,6 +60,7 @@ public class CardAdapter extends RecyclerView.Adapter<CardAdapter.CardViewHolder
         }
 
         Chip chip;
+        viewHolder.labels.removeAllViews();
         for(Label label: card.getLabels()) {
             chip = new Chip(context);
             chip.setText(label.getTitle());


### PR DESCRIPTION
* clear lables view before adding new labels - to prevent duplicates at refresh