### PR TITLE
[WIP] Add basic support for annotations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,8 @@ apply plugin: 'org.greenrobot.greendao'
 
 dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.1.4'
-    implementation 'com.github.nextcloud:android-SingleSignOn:0.1.2'
+    //implementation 'com.github.nextcloud:android-SingleSignOn:0.1.2'
+    compile project(':Android-SingleSignOn')
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/ApiProvider.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/ApiProvider.java
@@ -3,9 +3,12 @@ package it.niedermann.nextcloud.deck.api;
 import android.content.Context;
 
 import com.nextcloud.android.sso.api.NextcloudAPI;
+import com.nextcloud.android.sso.api.NextcloudRetrofitServiceMethod;
 import com.nextcloud.android.sso.exceptions.SSOException;
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
 import com.nextcloud.android.sso.model.SingleSignOnAccount;
+
+import retrofit2.NextcloudRetrofitApiBuilder;
 
 /**
  * Created by david on 26.05.17.
@@ -14,41 +17,24 @@ import com.nextcloud.android.sso.model.SingleSignOnAccount;
 public class ApiProvider {
 
     private static final String TAG = ApiProvider.class.getCanonicalName();
+    private static final String API_ENDPOINT = "/index.php/apps/deck/api/v1.0/";
+
     private DeckAPI mApi;
     private Context context;
-    private boolean connected = false;
-    NextcloudAPI nextcloudAPI = null;
-
 
     public ApiProvider(Context context) {
         this.context = context;
     }
 
-    public void initSsoApi(final NextcloudAPI.ApiConnectedListener callback) {
-
+    void initSsoApi(final NextcloudAPI.ApiConnectedListener callback) {
         try {
             SingleSignOnAccount ssoAccount = SingleAccountHelper.getCurrentSingleSignOnAccount(context);
-            nextcloudAPI = new NextcloudAPI(context, ssoAccount, GsonConfig.GetGson(), new NextcloudAPI.ApiConnectedListener() {
-                @Override
-                public void onConnected() {
-                    connected = true;
-                    mApi = new DeckAPI_SSO(nextcloudAPI);
-                    callback.onConnected();
-                }
-
-                @Override
-                public void onError(Exception ex) {
-                    ex.printStackTrace();
-                    callback.onError(ex);
-                }
-            });
+            NextcloudAPI nextcloudAPI = new NextcloudAPI(context, ssoAccount, GsonConfig.GetGson(), callback);
+            //mApi = new DeckAPI_SSO(nextcloudAPI);
+            mApi = new NextcloudRetrofitApiBuilder(nextcloudAPI, API_ENDPOINT).create(DeckAPI.class);
         } catch (SSOException e) {
             callback.onError(e);
         }
-    }
-
-    public boolean isConnected() {
-        return connected;
     }
 
     public DeckAPI getAPI() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI.java
@@ -24,10 +24,10 @@ public interface DeckAPI {
         Observable createBoard(@Body Board board);
 
         @GET("boards/{id}")
-        Observable<Board> getBoard(@Path("id") long id, @Header("If-Modified-Since") Date lastSync);
+        Observable<Board> getBoard(@Path("id") long id, @Header("If-Modified-Since") String lastSync);
 
         @GET("boards")
-        Observable<List<Board>> getBoards(@Header("If-Modified-Since") Date lastSync);
+        Observable<List<Board>> getBoards(@Header("If-Modified-Since") String lastSync);
 
 
         // ### Stacks
@@ -41,13 +41,13 @@ public interface DeckAPI {
         Observable<Stack> deleteStack(@Path("boardId") long boardId, @Path("stackId") long id);
 
         @GET("boards/{boardId}/stacks/{stackId}")
-        Observable<Stack> getStack(@Path("boardId") long boardId, @Path("stackId") long id, @Header("If-Modified-Since") Date lastSync);
+        Observable<Stack> getStack(@Path("boardId") long boardId, @Path("stackId") long id, @Header("If-Modified-Since") String lastSync);
 
         @GET("boards/{boardId}/stacks")
-        Observable<List<Stack>> getStacks(@Path("boardId") long boardId, @Header("If-Modified-Since") Date lastSync);
+        Observable<List<Stack>> getStacks(@Path("boardId") long boardId, @Header("If-Modified-Since") String lastSync);
 
         @GET("boards/{boardId}/stacks/archived")
-        Observable<List<Stack>> getArchivedStacks(@Path("boardId") long boardId, @Header("If-Modified-Since") Date lastSync);
+        Observable<List<Stack>> getArchivedStacks(@Path("boardId") long boardId, @Header("If-Modified-Since") String lastSync);
 
 
         // ### Cards
@@ -61,12 +61,12 @@ public interface DeckAPI {
         Observable<Card> deleteCard(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId);
 
         @GET("boards/{boardId}/stacks/{stackId}/cards/{cardId}")
-        Observable<Card> getCard(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId, @Header("If-Modified-Since") Date lastSync);
+        Observable<Card> getCard(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId, @Header("If-Modified-Since") String lastSync);
 
 
         // ### LABELS
         @GET("boards/{boardId}labels/{labelId}")
-        Observable<Label> getLabel(@Path("boardId") long boardId, @Path("labelId") long labelId, @Header("If-Modified-Since") Date lastSync);
+        Observable<Label> getLabel(@Path("boardId") long boardId, @Path("labelId") long labelId, @Header("If-Modified-Since") String lastSync);
 
         @PUT("boards/getBoards/{boardId}/labels/{labelId}")
         Observable<Label> updateLabel(@Path("boardId") long boardId, @Path("labelId") long labelId, @Body Label label);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI_SSO.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI_SSO.java
@@ -75,7 +75,7 @@ public class DeckAPI_SSO implements DeckAPI {
     }
 
     @Override
-    public Observable<List<Board>> getBoards(Date lastSync) {
+    public Observable<List<Board>> getBoards(String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards", lastSync).build();
 
         return nextcloudAPI.performRequestObservable(TypeToken.getParameterized(List.class, Board.class).getType(), request);
@@ -102,19 +102,19 @@ public class DeckAPI_SSO implements DeckAPI {
     }
 
     @Override
-    public Observable<Stack> getStack(long boardId, long id, Date lastSync) {
+    public Observable<Stack> getStack(long boardId, long id, String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards/{boardId}/stacks/{stackId}", lastSync, boardId, id).build();
         return nextcloudAPI.performRequestObservable(Stack.class, request);
     }
 
     @Override
-    public Observable<List<Stack>> getStacks(long boardId, Date lastSync) {
+    public Observable<List<Stack>> getStacks(long boardId, String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards/{boardId}/stacks", lastSync, boardId).build();
         return nextcloudAPI.performRequestObservable(TypeToken.getParameterized(List.class, Stack.class).getType(), request);
     }
 
     @Override
-    public Observable<List<Stack>> getArchivedStacks(long boardId, Date lastSync) {
+    public Observable<List<Stack>> getArchivedStacks(long boardId, String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards/{boardId}/stacks/archived", lastSync, boardId).build();
         return nextcloudAPI.performRequestObservable(TypeToken.getParameterized(List.class, Stack.class).getType(), request);
     }
@@ -140,13 +140,13 @@ public class DeckAPI_SSO implements DeckAPI {
     }
 
     @Override
-    public Observable<Card> getCard(long boardId, long stackId, long cardId, Date lastSync) {
+    public Observable<Card> getCard(long boardId, long stackId, long cardId, String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards/{boardId}/stacks/{stackId}/cards/{cardId}",lastSync, boardId, stackId, cardId).build();
         return nextcloudAPI.performRequestObservable(Card.class, request);
     }
 
     @Override
-    public Observable<Label> getLabel(long boardId, long labelId, Date lastSync) {
+    public Observable<Label> getLabel(long boardId, long labelId, String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards/"+boardId+"labels/"+labelId, lastSync).build();
         return nextcloudAPI.performRequestObservable(Label.class, request);
     }
@@ -180,7 +180,7 @@ public class DeckAPI_SSO implements DeckAPI {
     }
 
     @Override
-    public Observable<Board> getBoard(long id, Date lastSync) {
+    public Observable<Board> getBoard(long id, String lastSync) {
         NextcloudRequest request = buildRequest(GET, "boards/" + id, lastSync).build();
         return nextcloudAPI.performRequestObservable(Board.class, request);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/ServerAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/ServerAdapter.java
@@ -3,9 +3,15 @@ package it.niedermann.nextcloud.deck.persistence.sync.adapters;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import it.niedermann.nextcloud.deck.DeckConsts;
 import it.niedermann.nextcloud.deck.R;
@@ -17,6 +23,8 @@ import it.niedermann.nextcloud.deck.model.Card;
 import it.niedermann.nextcloud.deck.model.Stack;
 
 public class  ServerAdapter implements IPersistenceAdapter {
+
+    private static final DateFormat API_FORMAT = new SimpleDateFormat("E, d MMM yyyy hh:mm:ss z");
 
     private Context applicationContext;
     private ApiProvider provider;
@@ -31,8 +39,20 @@ public class  ServerAdapter implements IPersistenceAdapter {
                 applicationContext.getString(R.string.shared_preference_last_sync), Context.MODE_PRIVATE);
     }
 
+
+    private String getLastSyncDateFormatted() {
+        String lastSyncHeader = API_FORMAT.format(getLastSync());
+        // omit Offset of timezone (e.g.: +01:00)
+        if (lastSyncHeader.matches("^.*\\+[0-9]{2}:[0-9]{2}$")) {
+            lastSyncHeader = lastSyncHeader.substring(0, lastSyncHeader.length()-6);
+        }
+        Log.d("deck lastSync", lastSyncHeader);
+        return lastSyncHeader;
+    }
+
     private Date getLastSync() {
-        return null;
+        return new Date(1000000000000l);
+        //return null;
         // FIXME: reactivate, when lastSync is working in REST-API
 //        Date lastSync = new Date();
 //        lastSync.setTime(lastSyncPref.getLong(DeckConsts.LAST_SYNC_KEY, 0L));
@@ -41,7 +61,7 @@ public class  ServerAdapter implements IPersistenceAdapter {
 
     @Override
     public void getBoards(long accountId, IResponseCallback<List<Board>> responseCallback) {
-        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getBoards(getLastSync()), responseCallback);
+        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getBoards(getLastSyncDateFormatted()), responseCallback);
     }
 
     @Override
@@ -61,12 +81,12 @@ public class  ServerAdapter implements IPersistenceAdapter {
 
     @Override
     public void getStacks(long accountId, long boardId, IResponseCallback<List<Stack>> responseCallback) {
-        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getStacks(boardId, getLastSync()), responseCallback);
+        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getStacks(boardId, getLastSyncDateFormatted()), responseCallback);
     }
 
     @Override
     public void getStack(long accountId, long boardId, long stackId, IResponseCallback<Stack> responseCallback) {
-        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getStack(boardId, stackId, getLastSync()), responseCallback);
+        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getStack(boardId, stackId, getLastSyncDateFormatted()), responseCallback);
     }
 
     @Override
@@ -86,7 +106,7 @@ public class  ServerAdapter implements IPersistenceAdapter {
 
     @Override
     public void getCard(long accountId, long boardId, long stackId, long cardId, IResponseCallback<Card> responseCallback) {
-        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getCard(boardId, stackId, cardId, getLastSync()), responseCallback);
+        RequestHelper.request(sourceActivity, provider, () -> provider.getAPI().getCard(boardId, stackId, cardId, getLastSyncDateFormatted()), responseCallback);
     }
 
     @Override


### PR DESCRIPTION
This PR adds support for the new annotations introduced in the current SSO dev version. (Pull-Request: https://github.com/nextcloud/Android-SingleSignOn/pull/40).

I managed to reduce the amount of code in the ApiProvider to: 
```java
void initSsoApi(final NextcloudAPI.ApiConnectedListener callback) {
    try {
        SingleSignOnAccount ssoAccount = SingleAccountHelper.getCurrentSingleSignOnAccount(context);
        NextcloudAPI nextcloudAPI = new NextcloudAPI(context, ssoAccount, GsonConfig.GetGson(), callback);
        mApi = new NextcloudRetrofitApiBuilder(nextcloudAPI, API_ENDPOINT).create(DeckAPI.class);
    } catch (SSOException e) {
        callback.onError(e);
    }
}
```

The class `DeckAPI_SSO` is safe to delete now. 

To test this, clone the `add-annotations` branch from the `Android-SingleSignOn` repo in your project folder. I modified the `build.gradle` so that it'll pick it up automatically.

```
// Expected folder structure
./StudioProjects/nextcloud-deck/
                                app/
                                Android-SingleSignOn/
                                ...
```

I didn't manage to test all methods as I didn't manage to get deck running on my nextcloud yet. However most of the calls should work as expected (I wrote Unit Tests for all of them). 

In case you need to enable FollowRedirects, you should use the `@NextcloudAPI.FollowRedirects` annotation as seen in my tests: https://github.com/nextcloud/Android-SingleSignOn/blob/bda2ad5a5107bed395381daec625d1b62b2f2a5d/src/test/java/com/nextcloud/android/sso/api/API.java#L91

Due to the rewrite part of the `lastModifiedDate` ([here](https://github.com/stefan-niedermann/nextcloud-deck/blob/master/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI_SSO.java#L45)), I changed the signature of the endpoints from `Date` to `String` and passed in the date as the correctly formatted `String`. On my Server I'm still getting the following error message `{"status":500,"message":"Invalid If-Modified-Since header provided."}`. Not sure why this happens. The header field contains the correct information (as seen in the screenshot below).

<img width="504" alt="bildschirmfoto 2018-12-30 um 17 13 57" src="https://user-images.githubusercontent.com/4489723/50549037-73247280-0c56-11e9-8b44-1faa8fb39698.png">


Let me know what you guys think! :)