### PR TITLE
pragmatic fix for cut seemingly cut off at the bottom (#55)

### DIFF
--- a/app/src/main/res/layout/fragment_card.xml
+++ b/app/src/main/res/layout/fragment_card.xml
@@ -7,7 +7,8 @@
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/card_spacing"
     android:layout_marginLeft="@dimen/card_spacing"
-    android:layout_marginTop="@dimen/card_spacing"
+    android:layout_marginTop="@dimen/card_half_spacing"
+    android:layout_marginBottom="@dimen/card_half_spacing"
     android:layout_marginEnd="@dimen/card_spacing"
     android:layout_marginRight="@dimen/card_spacing"
     android:focusable="true">

--- a/app/src/main/res/layout/fragment_stack.xml
+++ b/app/src/main/res/layout/fragment_stack.xml
@@ -14,6 +14,8 @@
             android:layout_height="match_parent"
             android:scrollbars="vertical"
             android:paddingTop="@dimen/card_half_spacing"
-            android:paddingBottom="@dimen/card_half_spacing"/>
+            android:paddingBottom="@dimen/card_half_spacing"
+            android:clipToPadding="false"
+            android:scrollbarStyle="outsideOverlay" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_stack.xml
+++ b/app/src/main/res/layout/fragment_stack.xml
@@ -12,6 +12,8 @@
             android:id="@+id/recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbars="vertical" />
+            android:scrollbars="vertical"
+            android:paddingTop="@dimen/card_half_spacing"
+            android:paddingBottom="@dimen/card_half_spacing"/>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -12,5 +12,6 @@
     <dimen name="avatar_size">40dp</dimen>
     <dimen name="avatar_size_small">32dp</dimen>
     <dimen name="avatar_overlapping_small">20dp</dimen>
-    <dimen name="card_spacing">@dimen/activity_vertical_margin</dimen>
+    <dimen name="card_spacing">16dp</dimen>
+    <dimen name="card_half_spacing">8dp</dimen>
 </resources>


### PR DESCRIPTION
Hi,
I have a pragmatic fix for #55 . Unfortunately, simply adding a `paddingBottom` to the `RecyclerView` in `app/src/main/res/layout/fragment_stack.xml` gives a white margin. Am I doing something wrong here?

So instead, I propose a pragmatic fix, that shows the cards correctly, but there is a slight margin when scrolling.

Is that alright?

PS: I assume that `paddingBottom` in `RecyclerView` giving a white margin is due to there being another element which then in turn contains the cards. Do you know which one that could be?