### PR TITLE
Move title to actionbar

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/EditActivity.java
@@ -1,9 +1,12 @@
 package it.niedermann.nextcloud.deck.ui;
 
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.EditText;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -72,6 +75,11 @@ public class EditActivity extends AppCompatActivity {
         actionBar = Objects.requireNonNull(getSupportActionBar());
         actionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
         actionBar.setElevation(0);
+        actionBar.setCustomView(R.layout.fragment_edit_title);
+        actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM
+                | ActionBar.DISPLAY_HOME_AS_UP);
+        EditText title = actionBar.getCustomView().findViewById(
+                R.id.Title);
 
         Bundle extras = getIntent().getExtras();
         if (extras != null) {
@@ -86,7 +94,7 @@ public class EditActivity extends AppCompatActivity {
                 canEdit = fullBoard.getBoard().isPermissionEdit();
                 invalidateOptionsMenu();
                 if (createMode) {
-                    actionBar.setTitle(getString(R.string.add_card));
+                    title.setText(getString(R.string.add_card));
                     fullCard = new FullCard();
                     fullCard.setLabels(new ArrayList<>());
                     fullCard.setAssignedUsers(new ArrayList<>());
@@ -94,14 +102,57 @@ public class EditActivity extends AppCompatActivity {
                     card.setStackId(stackId);
                     fullCard.setCard(card);
                     setupViewPager();
+
+
+                    if(canEdit) {
+                        title.addTextChangedListener(new TextWatcher() {
+                            @Override
+                            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                                fullCard.getCard().setTitle(title.getText().toString());
+                                setTitle(title.getText().toString());
+                            }
+
+                            @Override
+                            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                            }
+
+                            @Override
+                            public void afterTextChanged(Editable s) {
+                            }
+                        });
+                    } else {
+                        title.setEnabled(false);
+                    }
                 } else {
                     observeOnce(syncManager.getCardByLocalId(accountId, localId), EditActivity.this, (next) -> {
-                        actionBar.setTitle(next.getCard().getTitle());
+                        title.setText(next.getCard().getTitle());
                         if (canEdit) {
-                            actionBar.setTitle(getString(R.string.edit) + " " + actionBar.getTitle());
+                            title.setText(getString(R.string.edit) + " " + actionBar.getTitle());
                         }
                         fullCard = next;
+                        title.setText(fullCard.getCard().getTitle());
                         setupViewPager();
+
+
+                        if(canEdit) {
+                            title.addTextChangedListener(new TextWatcher() {
+                                @Override
+                                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                                    fullCard.getCard().setTitle(title.getText().toString());
+                                    setTitle(title.getText().toString());
+                                }
+
+                                @Override
+                                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                                }
+
+                                @Override
+                                public void afterTextChanged(Editable s) {
+                                }
+                            });
+                        } else {
+                            title.setEnabled(false);
+                        }
                     });
                 }
             }));

--- a/app/src/main/res/layout/fragment_card_edit_tab_details.xml
+++ b/app/src/main/res/layout/fragment_card_edit_tab_details.xml
@@ -19,6 +19,7 @@
             android:importantForAutofill="no"
             android:textSize="20sp"
             android:layout_marginTop="@dimen/standard_margin"
+            android:visibility="gone"
             android:inputType="textPersonName" />
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_edit_title.xml
+++ b/app/src/main/res/layout/fragment_edit_title.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+android:layout_marginRight="16dp"
+    android:orientation="horizontal">
+
+    <EditText
+        android:id="@+id/Title"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:autofillHints="Title"
+        android:inputType="textFilter"
+        android:hint="Create"
+        android:contentDescription="Title"
+        tools:ignore="LabelFor,UnusedAttribute"
+        tools:text="Title" />
+</com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary</item>
         <item name="colorAccent">@color/primary</item>
+        <item name="colorControlActivated">@android:color/white</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="AppTheme">


### PR DESCRIPTION
This is a proof of concept and a follow-up to #53. This PR moves the separate title field to the actionbar. Previously it was redundant.

First i wanted to place the Create / Add label on the left of the title, but it took up too much space, so i went for a floating label.

To be honest, it feels very unfamiliar, maybe only because i do not use a single app which has the same behavior, but it's interesting and i am willing up to give it a try.

![grafik](https://user-images.githubusercontent.com/4741199/66808124-e0c23680-ef2a-11e9-8f34-6ebc8767fa40.png)

@jancborchardt and @jenniferpiperek because you brought this up at the Conf '19 :)