### PR TITLE
l10n: Uppercase for leading character

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,5 +143,5 @@
     <string name="simple_share">share</string>
     <string name="you_have_to_be_connected_to_the_internet_in_order_to_add_an_account">You have to be connected to the internet in order to add an account.</string>
     <string name="simple_select">Select</string>
-    <string name="owner">owner</string>
+    <string name="owner">Owner</string>
 </resources>


### PR DESCRIPTION
Reported at Transifex.

Signed-off-by: rakekniven <mark.ziegler@rakekniven.de>