### PR TITLE
Make attachment viewer swipeable

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/AttachmentsActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/AttachmentsActivity.java
@@ -1,14 +1,19 @@
 package it.niedermann.nextcloud.deck.ui;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MotionEvent;
+import android.view.View;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.SharedElementCallback;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
+import java.util.Map;
 
 import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ActivityAttachmentsBinding;
 import it.niedermann.nextcloud.deck.model.Attachment;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
@@ -19,6 +24,8 @@ import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_ACCOUN
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_LOCAL_ID;
 
 public class AttachmentsActivity extends AppCompatActivity {
+
+    private static final String TAG = AttachmentsActivity.class.getCanonicalName();
 
     private ActivityAttachmentsBinding binding;
 
@@ -31,6 +38,7 @@ public class AttachmentsActivity extends AppCompatActivity {
 
         binding = ActivityAttachmentsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        supportPostponeEnterTransition();
 
         setSupportActionBar(binding.toolbar);
 
@@ -66,18 +74,26 @@ public class AttachmentsActivity extends AppCompatActivity {
                     // TODO
                     // https://android-developers.googleblog.com/2018/02/continuous-shared-element-transitions.html?m=1
                     // https://github.com/android/animation-samples/blob/master/GridToPager/app/src/main/java/com/google/samples/gridtopager/fragment/ImagePagerFragment.java
-//                    setEnterSharedElementCallback(new SharedElementCallback() {
-//                        @Override
-//                        public void onMapSharedElements(List<String> names, Map<String, View> sharedElements) {
-//                            View view = binding.viewPager.getRootView();
-//                            if (view == null) {
-//                                return;
-//                            }
-//                            // Map the first shared element name to the child ImageView.
-//                            sharedElements.put(names.get(0), view.findViewById(R.id.image));
-//                            Log.v("SHARED", "names" + names);
-//                        }
-//                    });
+                    setEnterSharedElementCallback(new SharedElementCallback() {
+                        @Override
+                        public void onMapSharedElements(List<String> names, Map<String, View> sharedElements) {
+                            // Locate the image view at the primary fragment (the ImageFragment
+                            // that is currently visible). To locate the fragment, call
+                            // instantiateItem with the selection position.
+                            // At this stage, the method will simply return the fragment at the
+                            // position and will not create a new one.
+//                            ((AttachmentAdapter) binding.viewPager.getAdapter()).
+//                                        .(viewPager, binding.viewPager.getCurrentItem());
+
+                            // Map the first shared element name to the child ImageView.
+                            Log.i(TAG, "Mapping " + getString(R.string.transition_attachment_preview, String.valueOf(attachments.get(binding.viewPager.getCurrentItem()).getLocalId())) + " to " + binding.viewPager.getRootView().findViewById(R.id.preview));
+                            sharedElements.put(
+                                    getString(R.string.transition_attachment_preview, String.valueOf(attachments.get(binding.viewPager.getCurrentItem()).getLocalId())),
+                                    binding.viewPager.getRootView().findViewById(R.id.preview)
+                            );
+                            Log.v("SHARED", "names" + names);
+                        }
+                    });
                 }));
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/attachments/AttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/attachments/AttachmentAdapter.java
@@ -1,14 +1,21 @@
 package it.niedermann.nextcloud.deck.ui.attachments;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
 
 import java.util.List;
 
@@ -52,6 +59,23 @@ public class AttachmentAdapter extends RecyclerView.Adapter<AttachmentAdapter.At
                 holder.binding.preview.setImageResource(R.drawable.ic_image_grey600_24dp);
                 Glide.with(context)
                         .load(uri)
+                        .listener(new RequestListener<Drawable>() {
+                            @Override
+                            public boolean onLoadFailed(@Nullable GlideException e, Object model,
+                                                        Target<Drawable> target, boolean isFirstResource) {
+                                // TODO better cast check
+                                ((AppCompatActivity) context).supportStartPostponedEnterTransition();
+                                return false;
+                            }
+
+                            @Override
+                            public boolean onResourceReady(Drawable resource, Object model,
+                                                           Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                                // TODO better cast check
+                                ((AppCompatActivity) context).supportStartPostponedEnterTransition();
+                                return false;
+                            }
+                        })
                         .error(R.drawable.ic_image_grey600_24dp)
                         .into(holder.binding.preview);
             }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/attachments/AttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/attachments/AttachmentAdapter.java
@@ -8,7 +8,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -63,16 +63,18 @@ public class AttachmentAdapter extends RecyclerView.Adapter<AttachmentAdapter.At
                             @Override
                             public boolean onLoadFailed(@Nullable GlideException e, Object model,
                                                         Target<Drawable> target, boolean isFirstResource) {
-                                // TODO better cast check
-                                ((AppCompatActivity) context).supportStartPostponedEnterTransition();
+                                if (context instanceof FragmentActivity) {
+                                    ((FragmentActivity) context).supportStartPostponedEnterTransition();
+                                }
                                 return false;
                             }
 
                             @Override
                             public boolean onResourceReady(Drawable resource, Object model,
                                                            Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
-                                // TODO better cast check
-                                ((AppCompatActivity) context).supportStartPostponedEnterTransition();
+                                if (context instanceof FragmentActivity) {
+                                    ((FragmentActivity) context).supportStartPostponedEnterTransition();
+                                }
                                 return false;
                             }
                         })

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/attachments/AttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/attachments/AttachmentAdapter.java
@@ -1,0 +1,74 @@
+package it.niedermann.nextcloud.deck.ui.attachments;
+
+import android.content.Context;
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+
+import java.util.List;
+
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.databinding.ItemAttachmentBinding;
+import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.model.Attachment;
+import it.niedermann.nextcloud.deck.util.AttachmentUtil;
+
+public class AttachmentAdapter extends RecyclerView.Adapter<AttachmentAdapter.AttachmentViewHolder> {
+
+    private final Account account;
+    private final long cardRemoteId;
+    @NonNull
+    private List<Attachment> attachments;
+    private Context context;
+
+    public AttachmentAdapter(@NonNull Account account, long cardRemoteId, @NonNull List<Attachment> attachments) {
+        super();
+        this.attachments = attachments;
+        this.account = account;
+        this.cardRemoteId = cardRemoteId;
+    }
+
+    @NonNull
+    @Override
+    public AttachmentViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        this.context = parent.getContext();
+        return new AttachmentViewHolder(ItemAttachmentBinding.inflate(LayoutInflater.from(context), parent, false));
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull AttachmentViewHolder holder, int position) {
+        Attachment attachment = attachments.get(position);
+        String uri = AttachmentUtil.getUrl(account.getUrl(), cardRemoteId, attachment.getId());
+        if (attachment.getMimetype() != null) {
+            if (attachment.getMimetype().startsWith("image")) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    holder.binding.preview.setTransitionName(context.getString(R.string.transition_attachment_preview, String.valueOf(attachment.getLocalId())));
+                }
+                holder.binding.preview.setImageResource(R.drawable.ic_image_grey600_24dp);
+                Glide.with(context)
+                        .load(uri)
+                        .error(R.drawable.ic_image_grey600_24dp)
+                        .into(holder.binding.preview);
+            }
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return attachments.size();
+    }
+
+    static class AttachmentViewHolder extends RecyclerView.ViewHolder {
+        private ItemAttachmentBinding binding;
+
+        private AttachmentViewHolder(ItemAttachmentBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardActivityAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardActivityAdapter.java
@@ -15,13 +15,13 @@ import it.niedermann.nextcloud.deck.model.enums.ActivityType;
 import it.niedermann.nextcloud.deck.model.ocs.Activity;
 import it.niedermann.nextcloud.deck.util.DateUtil;
 
-public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.ActivitiesViewHolder> {
+public class CardActivityAdapter extends RecyclerView.Adapter<CardActivityAdapter.ActivitiesViewHolder> {
 
     @NonNull
     private List<Activity> activities;
     private Context context;
 
-    public ActivityAdapter(@NonNull List<Activity> activities) {
+    public CardActivityAdapter(@NonNull List<Activity> activities) {
         super();
         this.activities = activities;
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardActivityFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardActivityFragment.java
@@ -70,7 +70,7 @@ public class CardActivityFragment extends Fragment {
                     } else {
                         binding.emptyContentView.setVisibility(View.GONE);
                         binding.activitiesList.setVisibility(View.VISIBLE);
-                        RecyclerView.Adapter adapter = new ActivityAdapter(activities);
+                        RecyclerView.Adapter adapter = new CardActivityAdapter(activities);
                         binding.activitiesList.setAdapter(adapter);
                     }
                 }));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentAdapter.java
@@ -17,6 +17,7 @@ import android.widget.ImageView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -53,13 +54,24 @@ public class CardAttachmentAdapter extends RecyclerView.Adapter<CardAttachmentAd
     @NonNull
     private List<Attachment> attachments;
     @NonNull
-    private AttachmentDeletedListener attachmentDeletedListener;
+    private final AttachmentDeletedListener attachmentDeletedListener;
+    @Nullable
+    private final AttachmentClickedListener attachmentClickedListener;
     private Context context;
 
-    CardAttachmentAdapter(@NonNull MenuInflater menuInflator, @NonNull AttachmentDeletedListener attachmentDeletedListener, @NonNull Account account, long cardLocalId, long cardRemoteId, @NonNull List<Attachment> attachments) {
+    CardAttachmentAdapter(
+            @NonNull MenuInflater menuInflator,
+            @NonNull AttachmentDeletedListener attachmentDeletedListener,
+            @Nullable AttachmentClickedListener attachmentClickedListener,
+            @NonNull Account account,
+            long cardLocalId,
+            long cardRemoteId,
+            @NonNull List<Attachment> attachments
+    ) {
         super();
         this.menuInflator = menuInflator;
         this.attachmentDeletedListener = attachmentDeletedListener;
+        this.attachmentClickedListener = attachmentClickedListener;
         this.attachments = attachments;
         this.account = account;
         this.cardRemoteId = cardRemoteId;
@@ -119,6 +131,9 @@ public class CardAttachmentAdapter extends RecyclerView.Adapter<CardAttachmentAd
                         .into(holder.getPreview());
                 holder.getPreview().setImageResource(R.drawable.ic_image_grey600_24dp);
                 holder.getPreview().getRootView().setOnClickListener((v) -> {
+                    if (attachmentClickedListener != null) {
+                        attachmentClickedListener.onAttachmentClicked(position);
+                    }
                     Intent intent = new Intent(context, AttachmentsActivity.class);
                     intent.putExtra(BUNDLE_KEY_ACCOUNT_ID, account.getId());
                     intent.putExtra(BUNDLE_KEY_LOCAL_ID, cardLocalId);
@@ -241,5 +256,9 @@ public class CardAttachmentAdapter extends RecyclerView.Adapter<CardAttachmentAd
 
     public interface AttachmentDeletedListener {
         void onAttachmentDeleted(Attachment attachment);
+    }
+
+    public interface AttachmentClickedListener {
+        void onAttachmentClicked(int position);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentAdapter.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.text.format.Formatter;
-import android.transition.Explode;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuInflater;
@@ -42,7 +41,7 @@ import static it.niedermann.nextcloud.deck.ui.AttachmentsActivity.BUNDLE_KEY_CUR
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_ACCOUNT_ID;
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_LOCAL_ID;
 
-public class AttachmentAdapter extends RecyclerView.Adapter<AttachmentAdapter.AttachmentViewHolder> {
+public class CardAttachmentAdapter extends RecyclerView.Adapter<CardAttachmentAdapter.AttachmentViewHolder> {
 
     public static final int VIEW_TYPE_DEFAULT = 2;
     public static final int VIEW_TYPE_IMAGE = 1;
@@ -57,7 +56,7 @@ public class AttachmentAdapter extends RecyclerView.Adapter<AttachmentAdapter.At
     private AttachmentDeletedListener attachmentDeletedListener;
     private Context context;
 
-    AttachmentAdapter(@NonNull MenuInflater menuInflator, @NonNull AttachmentDeletedListener attachmentDeletedListener, @NonNull Account account, long cardLocalId, long cardRemoteId, @NonNull List<Attachment> attachments) {
+    CardAttachmentAdapter(@NonNull MenuInflater menuInflator, @NonNull AttachmentDeletedListener attachmentDeletedListener, @NonNull Account account, long cardLocalId, long cardRemoteId, @NonNull List<Attachment> attachments) {
         super();
         this.menuInflator = menuInflator;
         this.attachmentDeletedListener = attachmentDeletedListener;
@@ -126,8 +125,9 @@ public class AttachmentAdapter extends RecyclerView.Adapter<AttachmentAdapter.At
                     intent.putExtra(BUNDLE_KEY_CURRENT_ATTACHMENT_LOCAL_ID, attachment.getLocalId());
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && context instanceof Activity) {
-                        ((Activity) context).getWindow().setSharedElementEnterTransition(new Explode());
-                        context.startActivity(intent, ActivityOptionsCompat.makeSceneTransitionAnimation((Activity) context, holder.getPreview(), context.getString(R.string.transition_attachment_preview)).toBundle());
+                        String transitionName = context.getString(R.string.transition_attachment_preview, String.valueOf(attachment.getLocalId()));
+                        holder.getPreview().setTransitionName(transitionName);
+                        context.startActivity(intent, ActivityOptionsCompat.makeSceneTransitionAnimation((Activity) context, holder.getPreview(), transitionName).toBundle());
                     } else {
                         context.startActivity(intent);
                     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentsFragment.java
@@ -31,7 +31,7 @@ import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_BOARD_
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_CAN_EDIT;
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_LOCAL_ID;
 
-public class CardAttachmentsFragment extends Fragment implements AttachmentAdapter.AttachmentDeletedListener {
+public class CardAttachmentsFragment extends Fragment implements CardAttachmentAdapter.AttachmentDeletedListener {
     private static final String TAG = CardAttachmentsFragment.class.getCanonicalName();
 
     private FragmentCardEditTabAttachmentsBinding binding;
@@ -66,7 +66,7 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentAdapt
                     this.binding.emptyContentView.setVisibility(View.GONE);
                     this.binding.attachmentsList.setVisibility(View.VISIBLE);
                     syncManager.readAccount(accountId).observe(getViewLifecycleOwner(), (Account account) -> {
-                        RecyclerView.Adapter adapter = new AttachmentAdapter(
+                        RecyclerView.Adapter adapter = new CardAttachmentAdapter(
                                 requireActivity().getMenuInflater(),
                                 this,
                                 account,
@@ -74,15 +74,25 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentAdapt
                                 fullCard.getCard().getId(),
                                 fullCard.getAttachments());
                         binding.attachmentsList.setAdapter(adapter);
+
+                        // TODO
+                        // https://android-developers.googleblog.com/2018/02/continuous-shared-element-transitions.html?m=1
+                        // https://github.com/android/animation-samples/blob/master/GridToPager/app/src/main/java/com/google/samples/gridtopager/fragment/ImagePagerFragment.java
+//                        setExitSharedElementCallback(new SharedElementCallback() {
+//                            @Override
+//                            public void onMapSharedElements(List<String> names, Map<String, View> sharedElements) {
+//                                Log.v("SHARED", "names" + names);
+//                            }
+//                        });
                         GridLayoutManager glm = new GridLayoutManager(getActivity(), 3);
 
                         glm.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
                             @Override
                             public int getSpanSize(int position) {
                                 switch (adapter.getItemViewType(position)) {
-                                    case AttachmentAdapter.VIEW_TYPE_IMAGE:
+                                    case CardAttachmentAdapter.VIEW_TYPE_IMAGE:
                                         return 1;
-                                    case AttachmentAdapter.VIEW_TYPE_DEFAULT:
+                                    case CardAttachmentAdapter.VIEW_TYPE_DEFAULT:
                                         return 3;
                                     default:
                                         return 1;
@@ -94,7 +104,7 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentAdapt
                 }
             });
 
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT && canEdit) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && canEdit) {
                 binding.fab.setOnClickListener(v -> {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAttachmentsFragment.java
@@ -85,7 +85,6 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentDelet
                                 fullCard.getAttachments());
                         binding.attachmentsList.setAdapter(adapter);
 
-                        // TODO
                         // https://android-developers.googleblog.com/2018/02/continuous-shared-element-transitions.html?m=1
                         // https://github.com/android/animation-samples/blob/master/GridToPager/app/src/main/java/com/google/samples/gridtopager/fragment/ImagePagerFragment.java
                         setExitSharedElementCallback(new SharedElementCallback() {
@@ -93,15 +92,12 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentDelet
                             public void onMapSharedElements(List<String> names, Map<String, View> sharedElements) {
                                 CardAttachmentAdapter.AttachmentViewHolder selectedViewHolder = (CardAttachmentAdapter.AttachmentViewHolder) binding.attachmentsList
                                         .findViewHolderForAdapterPosition(clickedItemPosition);
-                                if (selectedViewHolder == null) {
-                                    Log.i(TAG, "selectedViewHolder is null");
-                                    return;
+                                if (selectedViewHolder != null) {
+                                    sharedElements.put(names.get(0), selectedViewHolder.getPreview());
                                 }
-                                Log.i(TAG, "Putting into map: " + names.get(0) + " = " + selectedViewHolder.getPreview());
-                                // Map the first shared element name to the child ImageView.
-                                sharedElements.put(names.get(0), selectedViewHolder.getPreview());
                             }
                         });
+
                         GridLayoutManager glm = new GridLayoutManager(getActivity(), 3);
 
                         glm.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {

--- a/app/src/main/res/layout/activity_attachments.xml
+++ b/app/src/main/res/layout/activity_attachments.xml
@@ -23,14 +23,14 @@
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="match_parent" />
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/image"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:contentDescription="@null"
-        android:transitionName="@string/transition_attachment_preview"
-        tools:src="@drawable/ic_image_grey600_24dp"
-        tools:targetApi="lollipop" />
+<!--    <androidx.appcompat.widget.AppCompatImageView-->
+<!--        android:id="@+id/image"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="match_parent"-->
+<!--        android:contentDescription="@null"-->
+<!--        android:transitionName="@string/transition_attachment_preview"-->
+<!--        tools:src="@drawable/ic_image_grey600_24dp"-->
+<!--        tools:targetApi="lollipop" />-->
 </LinearLayout>

--- a/app/src/main/res/layout/item_attachment.xml
+++ b/app/src/main/res/layout/item_attachment.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.AppCompatImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/preview"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:srcCompat="@drawable/ic_image_grey600_24dp" />

--- a/app/src/main/res/layout/item_attachment_default.xml
+++ b/app/src/main/res/layout/item_attachment_default.xml
@@ -20,7 +20,6 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="@dimen/standard_half_margin"
-            android:transitionName="@string/transition_attachment_preview"
             app:srcCompat="@drawable/ic_attach_file_grey600_24dp" />
 
         <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/main/res/layout/item_attachment_image.xml
+++ b/app/src/main/res/layout/item_attachment_image.xml
@@ -12,7 +12,6 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:scaleType="centerCrop"
-        android:transitionName="@string/transition_attachment_preview"
         app:srcCompat="@drawable/ic_image_grey600_24dp" />
 
     <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -35,5 +35,5 @@
     <integer name="minimum_server_app_patch" translatable="false">4</integer>
 
     <!-- Transitions -->
-    <string name="transition_attachment_preview" translatable="false">transition_attachment_preview</string>
+    <string name="transition_attachment_preview" translatable="false">transition_attachment_preview_%1$s</string>
 </resources>


### PR DESCRIPTION
Works, but currently we are loosing the fancy transitions compared to the `master`-branch, because we do no longer have a `1:1`-relation but a `n:n`-relation. Therefore we have to implement `SharedElementCallback`s, like in `CardAttachmentsFragment`:

```java
// https://android-developers.googleblog.com/2018/02/continuous-shared-element-transitions.html?m=1
// https://github.com/android/animation-samples/blob/master/GridToPager/app/src/main/java/com/google/samples/gridtopager/fragment/ImagePagerFragment.java
setExitSharedElementCallback(new SharedElementCallback() {
    @Override
    public void onMapSharedElements(List<String> names, Map<String, View> sharedElements) {
        Log.v("SHARED", "names" + names);
    }
});
```

(concrete implementation does not work yet but is comment in the code)