### PR TITLE
#341 Delete comments

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -326,7 +326,7 @@ public class SyncManager {
         doAsync(() -> {
             Account account = dataBaseAdapter.getAccountByIdDirectly(accountId);
             Card card = dataBaseAdapter.getCardByLocalIdDirectly(accountId, localCardId);
-            DeckComment entity = dataBaseAdapter.getCommentByRemoteIdDirectly(accountId, localCommentId);
+            DeckComment entity = dataBaseAdapter.getCommentByLocalIdDirectly(accountId, localCommentId);
             OcsComment commentEntity = OcsComment.of(entity);
             new DataPropagationHelper(serverAdapter, dataBaseAdapter).deleteEntity(new DeckCommentsDataProvider(null, card), commentEntity, new IResponseCallback<OcsComment>(account) {
                 @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/EditActivity.java
@@ -50,6 +50,7 @@ import it.niedermann.nextcloud.deck.ui.card.CardAttachmentsFragment.NewCardAttac
 import it.niedermann.nextcloud.deck.ui.card.CardDetailsFragment.CardDetailsListener;
 import it.niedermann.nextcloud.deck.ui.card.CardTabAdapter;
 import it.niedermann.nextcloud.deck.ui.card.comments.CommentAddedListener;
+import it.niedermann.nextcloud.deck.ui.card.comments.CommentDeletedListener;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 import it.niedermann.nextcloud.deck.util.CardUtil;
 
@@ -60,7 +61,7 @@ import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_LOCAL_
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.BUNDLE_KEY_STACK_ID;
 import static it.niedermann.nextcloud.deck.ui.card.CardAdapter.NO_LOCAL_ID;
 
-public class EditActivity extends AppCompatActivity implements CardDetailsListener, CommentAddedListener, NewCardAttachmentHandler, OnItemSelectedListener {
+public class EditActivity extends AppCompatActivity implements CardDetailsListener, CommentAddedListener, CommentDeletedListener, NewCardAttachmentHandler, OnItemSelectedListener {
 
     private ActivityEditBinding binding;
     private SyncManager syncManager;
@@ -425,5 +426,10 @@ public class EditActivity extends AppCompatActivity implements CardDetailsListen
     @Override
     public void attachmentRemoved(Attachment attachment) {
         fullCard.getAttachments().remove(attachment);
+    }
+
+    @Override
+    public void onCommentDeleted(Long localCommentId) {
+        syncManager.deleteComment(this.accountId, this.localId, localCommentId);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsAdapter.java
@@ -51,12 +51,15 @@ public class CardCommentsAdapter extends RecyclerView.Adapter<CardCommentsAdapte
     private final Account account;
     @NonNull
     private final MenuInflater menuInflater;
+    @NonNull
+    private final CommentDeletedListener commentDeletedListener;
 
-    CardCommentsAdapter(@NonNull Context context, @NonNull List<DeckComment> comments, @NonNull Account account, @NonNull MenuInflater menuInflater) {
+    CardCommentsAdapter(@NonNull Context context, @NonNull List<DeckComment> comments, @NonNull Account account, @NonNull MenuInflater menuInflater, @NonNull CommentDeletedListener commentDeletedListener) {
         this.context = context;
         this.comments = comments;
         this.account = account;
         this.menuInflater = menuInflater;
+        this.commentDeletedListener = commentDeletedListener;
         setHasStableIds(true);
     }
 
@@ -80,7 +83,7 @@ public class CardCommentsAdapter extends RecyclerView.Adapter<CardCommentsAdapte
         holder.binding.creationDateTime.setText(DateUtil.getRelativeDateTimeString(context, comment.getCreationDateTime().getTime()));
         holder.binding.getRoot().setOnClickListener(View::showContextMenu);
         holder.binding.getRoot().setOnCreateContextMenuListener((menu, v, menuInfo) -> {
-            menuInflater.inflate(R.menu.activity_menu, menu);
+            menuInflater.inflate(R.menu.comment_menu, menu);
             menu.findItem(android.R.id.copy).setOnMenuItemClickListener(item -> {
                 final ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(CLIPBOARD_SERVICE);
                 ClipData clipData = ClipData.newPlainText(comment.getMessage(), comment.getMessage());
@@ -91,6 +94,10 @@ public class CardCommentsAdapter extends RecyclerView.Adapter<CardCommentsAdapte
                 }
                 clipboardManager.setPrimaryClip(clipData);
                 Toast.makeText(context, R.string.simple_copied, Toast.LENGTH_SHORT).show();
+                return true;
+            });
+            menu.findItem(R.id.delete).setOnMenuItemClickListener(item -> {
+                commentDeletedListener.onCommentDeleted(comment.getLocalId());
                 return true;
             });
         });

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsFragment.java
@@ -46,6 +46,9 @@ public class CardCommentsFragment extends Fragment {
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
+        if (!(requireActivity() instanceof CommentDeletedListener)) {
+            throw new IllegalArgumentException("Caller must implement \"" + CommentDeletedListener.class.getCanonicalName() + "\"");
+        }
         Bundle args = getArguments();
         if (args == null || !args.containsKey(BUNDLE_KEY_ACCOUNT_ID) || !args.containsKey(BUNDLE_KEY_LOCAL_ID)) {
             throw new IllegalArgumentException("Arguments must at least contain an account and the local card id");
@@ -68,7 +71,7 @@ public class CardCommentsFragment extends Fragment {
                         if (comments != null && comments.size() > 0) {
                             binding.emptyContentView.setVisibility(GONE);
                             binding.comments.setVisibility(VISIBLE);
-                            binding.comments.setAdapter(new CardCommentsAdapter(requireContext(), comments, account, requireActivity().getMenuInflater()));
+                            binding.comments.setAdapter(new CardCommentsAdapter(requireContext(), comments, account, requireActivity().getMenuInflater(), (CommentDeletedListener) requireActivity()));
                         } else {
                             binding.emptyContentView.setVisibility(VISIBLE);
                             binding.comments.setVisibility(GONE);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CommentDeletedListener.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CommentDeletedListener.java
@@ -1,0 +1,5 @@
+package it.niedermann.nextcloud.deck.ui.card.comments;
+
+public interface CommentDeletedListener {
+    void onCommentDeleted(Long localId);
+}

--- a/app/src/main/res/menu/comment_menu.xml
+++ b/app/src/main/res/menu/comment_menu.xml
@@ -2,8 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@android:id/copyUrl"
-        android:title="@android:string/copyUrl"
+        android:id="@android:id/copy"
+        android:title="@android:string/copy"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/delete"


### PR DESCRIPTION
@desperateCoder looks like deleting comments is throwing exceptions instead of chocolate at me!

I debugged until this screenshot and i think i am passing the correct `localId` of the comment as parameter.

![grafik](https://user-images.githubusercontent.com/4741199/77768152-5c7bef80-7042-11ea-9ccf-566789a41b8e.png)

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Long it.niedermann.nextcloud.deck.model.ocs.comment.DeckComment.getLocalId()' on a null object reference
	at it.niedermann.nextcloud.deck.persistence.sync.adapters.db.dao.CommentDao_Impl$2.bind(CommentDao_Impl.java:112)
	at it.niedermann.nextcloud.deck.persistence.sync.adapters.db.dao.CommentDao_Impl$2.bind(CommentDao_Impl.java:104)
	at androidx.room.EntityDeletionOrUpdateAdapter.handleMultiple(EntityDeletionOrUpdateAdapter.java:107)
	at it.niedermann.nextcloud.deck.persistence.sync.adapters.db.dao.CommentDao_Impl.delete(CommentDao_Impl.java:225)
	at it.niedermann.nextcloud.deck.persistence.sync.adapters.db.dao.CommentDao_Impl.delete(CommentDao_Impl.java:24)
	at it.niedermann.nextcloud.deck.persistence.sync.adapters.db.DataBaseAdapter.deleteComment(DataBaseAdapter.java:668)
	at it.niedermann.nextcloud.deck.persistence.sync.helpers.providers.DeckCommentsDataProvider.deleteInDB(DeckCommentsDataProvider.java:77)
	at it.niedermann.nextcloud.deck.persistence.sync.helpers.providers.DeckCommentsDataProvider.deleteInDB(DeckCommentsDataProvider.java:14)
	at it.niedermann.nextcloud.deck.persistence.sync.helpers.DataPropagationHelper.deleteEntity(DataPropagationHelper.java:89)
	at it.niedermann.nextcloud.deck.persistence.sync.SyncManager.lambda$deleteComment$6$SyncManager(SyncManager.java:331)
	at it.niedermann.nextcloud.deck.persistence.sync.-$$Lambda$SyncManager$a969KBKxn5jIsmkaPQO0RD1PVds.run(Unknown Source:8)
	at java.lang.Thread.run(Thread.java:919)

```