### PR TITLE
Adds the ability to delete access controls

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -464,7 +464,7 @@ public class SyncManager {
         return liveData;
     }
 
-    public LiveData<Void> deleteAccessControl(AccessControl entity) {
+    public WrappedLiveData<Void> deleteAccessControl(AccessControl entity) {
         WrappedLiveData<Void> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             Account account = dataBaseAdapter.getAccountByIdDirectly(entity.getAccountId());
@@ -478,8 +478,7 @@ public class SyncManager {
 
                         @Override
                         public void onError(Throwable throwable) {
-                            liveData.setError(throwable);
-                            liveData.postValue(null);
+                            liveData.postError(throwable);
                         }
                     });
         });
@@ -491,8 +490,8 @@ public class SyncManager {
     }
 
 
-    public LiveData<Void> createStack(long accountId, Stack stack) {
-        WrappedLiveData<Void> liveData = new WrappedLiveData<>();
+    public WrappedLiveData<FullStack> createStack(long accountId, Stack stack) {
+        WrappedLiveData<FullStack> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             Account account = dataBaseAdapter.getAccountByIdDirectly(accountId);
             FullBoard board = dataBaseAdapter.getFullBoardByLocalIdDirectly(accountId, stack.getBoardId());
@@ -504,28 +503,6 @@ public class SyncManager {
             new DataPropagationHelper(serverAdapter, dataBaseAdapter).createEntity(new StackDataProvider(null, board), fullStack, new IResponseCallback<FullStack>(account) {
                 @Override
                 public void onResponse(FullStack response) {
-                    liveData.postValue(null);
-                }
-
-                @Override
-                public void onError(Throwable throwable) {
-                    liveData.setError(throwable);
-                    liveData.postValue(null);
-                }
-            });
-        });
-        return liveData;
-    }
-
-    public LiveData<FullStack> deleteStack(Stack stack) {
-        MutableLiveData<FullStack> liveData = new MutableLiveData<>();
-        doAsync(() -> {
-            Account account = dataBaseAdapter.getAccountByIdDirectly(stack.getAccountId());
-            FullStack fullStack = dataBaseAdapter.getFullStackByLocalIdDirectly(stack.getLocalId());
-            FullBoard board = dataBaseAdapter.getFullBoardByLocalIdDirectly(stack.getAccountId(), stack.getBoardId());
-            new DataPropagationHelper(serverAdapter, dataBaseAdapter).deleteEntity(new StackDataProvider(null, board), fullStack, new IResponseCallback<FullStack>(account) {
-                @Override
-                public void onResponse(FullStack response) {
                     liveData.postValue(response);
                 }
             });
@@ -533,8 +510,29 @@ public class SyncManager {
         return liveData;
     }
 
-    public LiveData<FullStack> updateStack(FullStack stack) {
-        MutableLiveData<FullStack> liveData = new MutableLiveData<>();
+    public WrappedLiveData<Void> deleteStack(Stack stack) {
+        WrappedLiveData<Void> liveData = new WrappedLiveData<>();
+        doAsync(() -> {
+            Account account = dataBaseAdapter.getAccountByIdDirectly(stack.getAccountId());
+            FullStack fullStack = dataBaseAdapter.getFullStackByLocalIdDirectly(stack.getLocalId());
+            FullBoard board = dataBaseAdapter.getFullBoardByLocalIdDirectly(stack.getAccountId(), stack.getBoardId());
+            new DataPropagationHelper(serverAdapter, dataBaseAdapter).deleteEntity(new StackDataProvider(null, board), fullStack, new IResponseCallback<FullStack>(account) {
+                @Override
+                public void onResponse(FullStack response) {
+                    liveData.postValue(null);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    liveData.postError(throwable);
+                }
+            });
+        });
+        return liveData;
+    }
+
+    public WrappedLiveData<FullStack> updateStack(FullStack stack) {
+        WrappedLiveData<FullStack> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             Account account = dataBaseAdapter.getAccountByIdDirectly(stack.getAccountId());
             FullBoard board = dataBaseAdapter.getFullBoardByLocalIdDirectly(stack.getAccountId(), stack.getStack().getBoardId());
@@ -544,7 +542,7 @@ public class SyncManager {
 
     }
 
-    private void updateStack(Account account, FullBoard board, FullStack stack, MutableLiveData<FullStack> liveData) {
+    private void updateStack(Account account, FullBoard board, FullStack stack, WrappedLiveData<FullStack> liveData) {
         doAsync(() -> {
             new DataPropagationHelper(serverAdapter, dataBaseAdapter).updateEntity(new StackDataProvider(null, board), stack, new IResponseCallback<FullStack>(account) {
                 @Override
@@ -552,6 +550,11 @@ public class SyncManager {
                     if (liveData != null) {
                         liveData.postValue(response);
                     }
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    liveData.postError(throwable);
                 }
             });
         });
@@ -651,8 +654,8 @@ public class SyncManager {
         return liveData;
     }
 
-    public MutableLiveData<FullCard> deleteCard(Card card) {
-        MutableLiveData<FullCard> liveData = new MutableLiveData<>();
+    public WrappedLiveData<FullCard> deleteCard(Card card) {
+        WrappedLiveData<FullCard> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             FullCard fullCard = dataBaseAdapter.getFullCardByLocalIdDirectly(card.getAccountId(), card.getLocalId());
             if (fullCard == null) {
@@ -666,12 +669,18 @@ public class SyncManager {
                 public void onResponse(FullCard response) {
                     liveData.postValue(response);
                 }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    liveData.postError(throwable);
+                }
+
             });
         });
         return liveData;
     }
 
-    public MutableLiveData<FullCard> archiveCard(FullCard card) {
+    public WrappedLiveData<FullCard> archiveCard(FullCard card) {
         card.getCard().setArchived(true);
         return updateCard(card);
     }
@@ -681,8 +690,8 @@ public class SyncManager {
         return null;
     }
 
-    public MutableLiveData<FullCard> updateCard(FullCard card) {
-        MutableLiveData<FullCard> liveData = new MutableLiveData<>();
+    public WrappedLiveData<FullCard> updateCard(FullCard card) {
+        WrappedLiveData<FullCard> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             FullCard fullCardFromDB = dataBaseAdapter.getFullCardByLocalIdDirectly(card.getAccountId(), card.getLocalId());
             if (fullCardFromDB == null) {
@@ -720,6 +729,11 @@ public class SyncManager {
                             @Override
                             public void onResponse(Boolean response) {
                                 liveData.postValue(dataBaseAdapter.getFullCardByLocalIdDirectly(card.getAccountId(), card.getLocalId()));
+                            }
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                                liveData.postError(throwable);
                             }
                         }).doUpSyncFor(new CardPropagationDataProvider(null, board, stack));
             } else {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -444,7 +444,7 @@ public class SyncManager {
         return dataBaseAdapter.getAccessControlByRemoteIdDirectly(accountId, id);
     }
 
-    public LiveData<List<AccessControl>> getAccessControlByLocalBoardId(long accountId, Long id) {
+    public LiveData<List<AccessControl>>  getAccessControlByLocalBoardId(long accountId, Long id) {
         return dataBaseAdapter.getAccessControlByLocalBoardId(accountId, id);
     }
 
@@ -464,8 +464,8 @@ public class SyncManager {
         return liveData;
     }
 
-    public MutableLiveData<AccessControl> deleteAccessControl(AccessControl entity) {
-        MutableLiveData<AccessControl> liveData = new MutableLiveData<>();
+    public LiveData<Void> deleteAccessControl(AccessControl entity) {
+        WrappedLiveData<Void> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             Account account = dataBaseAdapter.getAccountByIdDirectly(entity.getAccountId());
             FullBoard board = dataBaseAdapter.getFullBoardByLocalIdDirectly(entity.getAccountId(), entity.getBoardId());
@@ -473,7 +473,13 @@ public class SyncManager {
                     new AccessControlDataProvider(null, board, Collections.singletonList(entity)), entity, new IResponseCallback<AccessControl>(account) {
                         @Override
                         public void onResponse(AccessControl response) {
-                            liveData.postValue(response);
+                            liveData.postValue(null);
+                        }
+
+                        @Override
+                        public void onError(Throwable throwable) {
+                            liveData.setError(throwable);
+                            liveData.postValue(null);
                         }
                     });
         });
@@ -485,8 +491,8 @@ public class SyncManager {
     }
 
 
-    public LiveData<FullStack> createStack(long accountId, Stack stack) {
-        MutableLiveData<FullStack> liveData = new MutableLiveData<>();
+    public LiveData<Void> createStack(long accountId, Stack stack) {
+        WrappedLiveData<Void> liveData = new WrappedLiveData<>();
         doAsync(() -> {
             Account account = dataBaseAdapter.getAccountByIdDirectly(accountId);
             FullBoard board = dataBaseAdapter.getFullBoardByLocalIdDirectly(accountId, stack.getBoardId());
@@ -498,7 +504,13 @@ public class SyncManager {
             new DataPropagationHelper(serverAdapter, dataBaseAdapter).createEntity(new StackDataProvider(null, board), fullStack, new IResponseCallback<FullStack>(account) {
                 @Override
                 public void onResponse(FullStack response) {
-                    liveData.postValue(response);
+                    liveData.postValue(null);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    liveData.setError(throwable);
+                    liveData.postValue(null);
                 }
             });
         });

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DataBaseAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DataBaseAdapter.java
@@ -433,8 +433,12 @@ public class DataBaseAdapter {
     }
 
     public void deleteAccessControl(AccessControl entity, boolean setStatus) {
-        markAsEditedIfNeeded(entity, setStatus);
-        db.getAccessControlDao().update(entity);
+        markAsDeletedIfNeeded(entity, setStatus);
+        if (setStatus){
+            db.getAccessControlDao().update(entity);
+        } else {
+            db.getAccessControlDao().delete(entity);
+        }
     }
 
     public LiveData<FullBoard> getFullBoardById(Long accountId, Long localId) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/dao/AccessControlDao.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/dao/AccessControlDao.java
@@ -14,7 +14,7 @@ public interface AccessControlDao extends GenericDao<AccessControl> {
     @Query("SELECT * FROM AccessControl WHERE accountId = :accountId and id = :remoteId")
     LiveData<AccessControl> getAccessControlByRemoteId(final long accountId, final long remoteId);
 
-    @Query("SELECT * FROM AccessControl WHERE accountId = :accountId and boardId = :localBoardId")
+    @Query("SELECT * FROM AccessControl WHERE accountId = :accountId and boardId = :localBoardId and status <> 3")
     LiveData<List<AccessControl>> getAccessControlByLocalBoardId(final long accountId, final long localBoardId);
 
     @Query("SELECT * FROM AccessControl WHERE accountId = :accountId and id = :remoteId")

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
@@ -23,6 +23,10 @@ public class WrappedLiveData <T> extends MutableLiveData <T> {
         this.error = new RuntimeException("LiveData failed: see cause!", e);
     }
 
+    public RuntimeException getError() {
+        return error;
+    }
+
     public void postError(RuntimeException e){
         setError(e);
         postValue(null);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
@@ -22,4 +22,14 @@ public class WrappedLiveData <T> extends MutableLiveData <T> {
     public void setError(Throwable e) {
         this.error = new RuntimeException("LiveData failed: see cause!", e);
     }
+
+    public void postError(RuntimeException e){
+        setError(e);
+        postValue(null);
+    }
+
+    public void postError(Throwable e){
+        setError(e);
+        postValue(null);
+    }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
@@ -18,4 +18,8 @@ public class WrappedLiveData <T> extends MutableLiveData <T> {
     public void setError(RuntimeException e) {
         this.error = e;
     }
+
+    public void setError(Throwable e) {
+        this.error = new RuntimeException("LiveData failed: see cause!", e);
+    }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/SyncHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/SyncHelper.java
@@ -108,7 +108,7 @@ public class SyncHelper {
         return new IResponseCallback<Void>(account) {
             @Override
             public void onResponse(Void response) {
-                provider.deleteInDB(dataBaseAdapter, accountId, entity);
+                provider.deletePhysicallyInDB(dataBaseAdapter, accountId, entity);
                 provider.goDeeperForUpSync(SyncHelper.this, serverAdapter, dataBaseAdapter, responseCallback);
             }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/providers/AccessControlDataProvider.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/providers/AccessControlDataProvider.java
@@ -78,6 +78,11 @@ public class AccessControlDataProvider extends AbstractSyncDataProvider<AccessCo
     }
 
     @Override
+    public void deletePhysicallyInDB(DataBaseAdapter dataBaseAdapter, long accountId, AccessControl accessControl) {
+        dataBaseAdapter.deleteAccessControl(accessControl, false);
+    }
+
+    @Override
     public void deleteOnServer(ServerAdapter serverAdapter, long accountId, IResponseCallback<Void> callback, AccessControl entity, DataBaseAdapter dataBaseAdapter) {
         serverAdapter.deleteAccessControl(board.getBoard().getId(), entity, callback);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlAdapter.java
@@ -132,6 +132,7 @@ public class AccessControlAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public void update(@NonNull List<AccessControl> accessControls) {
+        this.accessControls.clear();
         this.accessControls.addAll(accessControls);
         notifyDataSetChanged();
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
@@ -1,15 +1,14 @@
 package it.niedermann.nextcloud.deck.ui.board.accesscontrol;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
 
@@ -24,6 +23,8 @@ import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
 import it.niedermann.nextcloud.deck.ui.card.UserAutoCompleteAdapter;
 
+import static it.niedermann.nextcloud.deck.ui.board.accesscontrol.AccessControlAdapter.HEADER_ITEM_LOCAL_ID;
+
 public class AccessControlDialogFragment extends BrandedDialogFragment implements AccessControlChangedListener, OnItemClickListener {
 
     private DialogBoardShareBinding binding;
@@ -35,6 +36,7 @@ public class AccessControlDialogFragment extends BrandedDialogFragment implement
     private long boardId;
     private SyncManager syncManager;
     private UserAutoCompleteAdapter userAutoCompleteAdapter;
+    private AccessControlAdapter adapter;
 
     /**
      * Use newInstance()-Method
@@ -42,34 +44,47 @@ public class AccessControlDialogFragment extends BrandedDialogFragment implement
     public AccessControlDialogFragment() {
     }
 
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        final Bundle args = getArguments();
+
+        if (args == null || !args.containsKey(KEY_BOARD_ID) || !args.containsKey(KEY_ACCOUNT_ID)) {
+            throw new IllegalArgumentException(KEY_ACCOUNT_ID + " and " + KEY_BOARD_ID + " must be provided as arguments");
+        }
+
+        this.boardId = requireArguments().getLong(KEY_BOARD_ID);
+        this.accountId = requireArguments().getLong(KEY_ACCOUNT_ID);
+
+        if (this.boardId == 0L || this.accountId == 0L) {
+            throw new IllegalArgumentException(KEY_ACCOUNT_ID + " and " + KEY_BOARD_ID + " must be valid localIds and not be 0");
+        }
+    }
+
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        final AlertDialog.Builder dialogBuilder = new BrandedAlertDialogBuilder(requireContext());
+
         binding = DialogBoardShareBinding.inflate(requireActivity().getLayoutInflater());
-        boardId = requireArguments().getLong(KEY_BOARD_ID);
-        accountId = requireArguments().getLong(KEY_ACCOUNT_ID);
+        adapter = new AccessControlAdapter(this, getContext());
+        binding.peopleList.setAdapter(adapter);
 
-        AlertDialog.Builder dialogBuilder = new BrandedAlertDialogBuilder(requireContext());
-
-        if (boardId == 0L || accountId == 0L) {
-            throw new IllegalArgumentException("accountId and boardId must be provided");
-        } else {
-            syncManager = new SyncManager(requireActivity());
-            syncManager.getFullBoardById(accountId, boardId).observe(this, (FullBoard fullBoard) -> {
-                syncManager.getAccessControlByLocalBoardId(accountId, boardId).observe(this, (List<AccessControl> accessControlList) -> {
-                    AccessControl ownerControl = new AccessControl();
-                    ownerControl.setUser(fullBoard.getOwner());
-                    accessControlList.add(0, ownerControl);
-                    RecyclerView.Adapter adapter = new AccessControlAdapter(accessControlList, this, getContext());
-                    binding.peopleList.setAdapter(adapter);
-                    userAutoCompleteAdapter = new UserAutoCompleteAdapter(requireActivity(), accountId, boardId);
-                    binding.people.setAdapter(userAutoCompleteAdapter);
-                    binding.people.setOnItemClickListener(this);
-                });
+        syncManager = new SyncManager(requireActivity());
+        syncManager.getFullBoardById(accountId, boardId).observe(this, (FullBoard fullBoard) -> {
+            syncManager.getAccessControlByLocalBoardId(accountId, boardId).observe(this, (List<AccessControl> accessControlList) -> {
+                final AccessControl ownerControl = new AccessControl();
+                ownerControl.setLocalId(HEADER_ITEM_LOCAL_ID);
+                ownerControl.setUser(fullBoard.getOwner());
+                accessControlList.add(0, ownerControl);
+                adapter.update(accessControlList);
+                userAutoCompleteAdapter = new UserAutoCompleteAdapter(requireActivity(), accountId, boardId);
+                binding.people.setAdapter(userAutoCompleteAdapter);
+                binding.people.setOnItemClickListener(this);
             });
-        }
-
+        });
         return dialogBuilder
                 .setView(binding.getRoot())
                 .setPositiveButton(R.string.simple_close, null)
@@ -94,14 +109,14 @@ public class AccessControlDialogFragment extends BrandedDialogFragment implement
 
     @Override
     public void deleteAccessControl(AccessControl ac) {
-        // TODO implement in syncManager!
-        Toast.makeText(getContext(), "Deleting user permissions is not yet supported.", Toast.LENGTH_LONG).show();
+        syncManager.deleteAccessControl(ac);
+        adapter.remove(ac);
     }
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        AccessControl ac = new AccessControl();
-        User user = userAutoCompleteAdapter.getItem(position);
+        final AccessControl ac = new AccessControl();
+        final User user = userAutoCompleteAdapter.getItem(position);
         ac.setPermissionEdit(true);
         ac.setBoardId(boardId);
         ac.setType(0L); // https://github.com/nextcloud/deck/blob/master/docs/API.md#post-boardsboardidacl---add-new-acl-rule

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
@@ -21,13 +21,13 @@ import it.niedermann.nextcloud.deck.model.AccessControl;
 import it.niedermann.nextcloud.deck.model.User;
 import it.niedermann.nextcloud.deck.model.full.FullBoard;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
-import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper;
 import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.WrappedLiveData;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
 import it.niedermann.nextcloud.deck.ui.card.UserAutoCompleteAdapter;
 
+import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
 import static it.niedermann.nextcloud.deck.ui.board.accesscontrol.AccessControlAdapter.HEADER_ITEM_LOCAL_ID;
 
 public class AccessControlDialogFragment extends BrandedDialogFragment implements AccessControlChangedListener, OnItemClickListener {
@@ -115,7 +115,7 @@ public class AccessControlDialogFragment extends BrandedDialogFragment implement
     @Override
     public void deleteAccessControl(AccessControl ac) {
         final WrappedLiveData<Void> wrappedDeleteLiveData = syncManager.deleteAccessControl(ac);
-        LiveDataHelper.observeOnce(wrappedDeleteLiveData, this, (ignored) -> {
+        observeOnce(wrappedDeleteLiveData, this, (ignored) -> {
             if (wrappedDeleteLiveData.hasError()) {
                 Toast.makeText(requireContext(), getString(R.string.error_revoking_ac, ac.getUser().getDisplayname()), Toast.LENGTH_LONG).show();
                 DeckLog.logError(wrappedDeleteLiveData.getError());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,4 +182,5 @@
     <string name="open_in_browser">Open in browser</string>
     <string name="simple_open">Open</string>
     <string name="updating_card">Updating card…</string>
+    <string name="error_revoking_ac">Error while revoking the access for %1$s</string>
 </resources>


### PR DESCRIPTION
@desperateCoder there is something wrong with deleting access controls.

The request to the server is done and successful (The access control is no longer present according to the web interface).

Protocol of the delete request:

```
I/Choreographer: Skipped 1123 frames!  The application may be doing too much work on its main thread.
D/EGL_emulation: eglMakeCurrent: 0x707617a37f40: ver 2 0 (tinfo 0x7076179f85e0)
D/com.nextcloud.android.sso.api.NetworkRequest: [connectApiWithBackoff] connectApiWithBackoff() called from Thread: [Thread-102]
D/EGL_emulation: eglMakeCurrent: 0x707617a37f40: ver 2 0 (tinfo 0x7076179f85e0)
D/com.nextcloud.android.sso.api.NextcloudRetrofitServiceMethod: NextcloudRetrofitServiceMethod() called with: apiEndpoint = [/index.php/apps/deck/api/v1.0/], method = [public abstract io.reactivex.Observable it.niedermann.nextcloud.deck.api.DeckAPI.deleteAccessControl(long,long,it.niedermann.nextcloud.deck.model.AccessControl)]
D/com.nextcloud.android.sso.api.NetworkRequest: [connectApiWithBackoff] trying to connect..
D/com.nextcloud.android.sso.api.AidlNetworkRequest: [connect] Binding to AccountManagerService for type [nextcloud]
D/com.nextcloud.android.sso.api.NetworkRequest: [connect] connect() called [main] Account-Type: [nextcloud]
D/com.nextcloud.android.sso.api.AidlNetworkRequest: [connect] Component name is: [com.nextcloud.client]
D/com.nextcloud.android.sso.api.AidlNetworkRequest: [connect] Bound to AccountManagerService successfully
D/com.nextcloud.android.sso.api.AidlNetworkRequest: [onServiceConnected] called from Thread: [main] with IBinder [ComponentInfo{com.nextcloud.client/com.owncloud.android.services.AccountManagerService}]: android.os.BinderProxy@54532d0
D/com.nextcloud.android.sso.api.NextcloudRetrofitServiceMethod: invoke call to api using observable class java.lang.Void
D/com.nextcloud.android.sso.api.NextcloudAPI: performRequest() called with: type = [class java.lang.Void], request = [NextcloudRequest(method=DELETE, header={}, parameter={}, requestBody={"boardId":1,"owner":false,"permissionEdit":true,"permissionManage":true,"permissionShare":true,"type":0,"participant":{"displayname":"artur","primaryKey":"artur","uid":"artur","accountId":1,"localId":2,"status":1},"userId":2,"accountId":1,"id":17,"lastModifiedLocal":"2020-04-18T09:14:46.501Z","localId":1,"status":2}, url=/index.php/apps/deck/api/v1.0/boards/98/acl/17, token=null, packageName=null, accountName=null, bodyAsStream=null, followRedirects=false)]
D/com.nextcloud.android.sso.api.AidlNetworkRequest: copy data from service finished
```

Also the LiveData fires after the deletion request has been made.

The problem is: The new LiveData still contains the just deleted record.

In the aftermath i can see the old deleted record everytime i open the share-dialog, even after performing a full sync - only deleting the storage of the app helps to get rid of it.

I can also see this stacktrace:

```
2020-04-18 11:16:04.066 26846-26846/it.niedermann.nextcloud.deck.dev D/DeckLog: onError() (IResponseCallback.java:21) -> com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException: HTTP request failed with HTTP status-code: 500
        at com.nextcloud.android.sso.api.AidlNetworkRequest.performNetworkRequest(AidlNetworkRequest.java:202)
        at com.nextcloud.android.sso.api.NextcloudAPI.performNetworkRequest(NextcloudAPI.java:119)
        at com.nextcloud.android.sso.api.NextcloudAPI.performRequest(NextcloudAPI.java:98)
        at com.nextcloud.android.sso.api.NextcloudAPI.lambda$performRequestObservable$0$NextcloudAPI(NextcloudAPI.java:86)
        at com.nextcloud.android.sso.api.-$$Lambda$NextcloudAPI$yhhE-DMCe81fXF-bhjup5Tra-6o.subscribe(Unknown Source:6)
        at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
        at io.reactivex.Observable.subscribe(Observable.java:12284)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalStateException: {"status":500,"message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","exception":{"\u0000*\u0000message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","\u0000Exception\u0000string":"","\u0000*\u0000code":0,"\u0000*\u0000file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","\u0000*\u0000line":283,"\u0000Exception\u0000trace":[{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","line":371,"function":"findOneQuery","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"],null,null]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/DeckMapper.php","line":45,"function":"findEntity","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"]]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/AclMapper.php","line":47,"function":"find","class":"OCA\\Deck\\Db\\DeckMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/PermissionService.php","line":139,"function":"findBoardId","class":"OCA\\Deck\\Db\\AclMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/BoardService.php","line":570,"function":"checkPermission","class":"OCA\\Deck\\Service\\PermissionService","type":"-\u003E","args":[{},"17",2]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Controller\/BoardApiController.php","line":165,"function":"updateAcl","class":"OCA\\Deck\\Service\\BoardService","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"updateAcl","class":"OCA\\Deck\\Controller\\BoardApiController","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhost
2020-04-18 11:16:04.070 26846-26846/it.niedermann.nextcloud.deck.dev D/DeckLog: onError() (IResponseCallback.java:21) -> com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException: HTTP request failed with HTTP status-code: 500
        at com.nextcloud.android.sso.api.AidlNetworkRequest.performNetworkRequest(AidlNetworkRequest.java:202)
        at com.nextcloud.android.sso.api.NextcloudAPI.performNetworkRequest(NextcloudAPI.java:119)
        at com.nextcloud.android.sso.api.NextcloudAPI.performRequest(NextcloudAPI.java:98)
        at com.nextcloud.android.sso.api.NextcloudAPI.lambda$performRequestObservable$0$NextcloudAPI(NextcloudAPI.java:86)
        at com.nextcloud.android.sso.api.-$$Lambda$NextcloudAPI$yhhE-DMCe81fXF-bhjup5Tra-6o.subscribe(Unknown Source:6)
        at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
        at io.reactivex.Observable.subscribe(Observable.java:12284)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalStateException: {"status":500,"message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","exception":{"\u0000*\u0000message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","\u0000Exception\u0000string":"","\u0000*\u0000code":0,"\u0000*\u0000file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","\u0000*\u0000line":283,"\u0000Exception\u0000trace":[{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","line":371,"function":"findOneQuery","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"],null,null]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/DeckMapper.php","line":45,"function":"findEntity","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"]]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/AclMapper.php","line":47,"function":"find","class":"OCA\\Deck\\Db\\DeckMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/PermissionService.php","line":139,"function":"findBoardId","class":"OCA\\Deck\\Db\\AclMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/BoardService.php","line":570,"function":"checkPermission","class":"OCA\\Deck\\Service\\PermissionService","type":"-\u003E","args":[{},"17",2]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Controller\/BoardApiController.php","line":165,"function":"updateAcl","class":"OCA\\Deck\\Service\\BoardService","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"updateAcl","class":"OCA\\Deck\\Controller\\BoardApiController","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhost
2020-04-18 11:16:04.072 26846-27299/it.niedermann.nextcloud.deck.dev D/DeckLog: onError() (IResponseCallback.java:21) -> com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException: HTTP request failed with HTTP status-code: 500
        at com.nextcloud.android.sso.api.AidlNetworkRequest.performNetworkRequest(AidlNetworkRequest.java:202)
        at com.nextcloud.android.sso.api.NextcloudAPI.performNetworkRequest(NextcloudAPI.java:119)
        at com.nextcloud.android.sso.api.NextcloudAPI.performRequest(NextcloudAPI.java:98)
        at com.nextcloud.android.sso.api.NextcloudAPI.lambda$performRequestObservable$0$NextcloudAPI(NextcloudAPI.java:86)
        at com.nextcloud.android.sso.api.-$$Lambda$NextcloudAPI$yhhE-DMCe81fXF-bhjup5Tra-6o.subscribe(Unknown Source:6)
        at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
        at io.reactivex.Observable.subscribe(Observable.java:12284)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalStateException: {"status":500,"message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","exception":{"\u0000*\u0000message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","\u0000Exception\u0000string":"","\u0000*\u0000code":0,"\u0000*\u0000file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","\u0000*\u0000line":283,"\u0000Exception\u0000trace":[{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","line":371,"function":"findOneQuery","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"],null,null]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/DeckMapper.php","line":45,"function":"findEntity","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"]]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/AclMapper.php","line":47,"function":"find","class":"OCA\\Deck\\Db\\DeckMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/PermissionService.php","line":139,"function":"findBoardId","class":"OCA\\Deck\\Db\\AclMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/BoardService.php","line":570,"function":"checkPermission","class":"OCA\\Deck\\Service\\PermissionService","type":"-\u003E","args":[{},"17",2]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Controller\/BoardApiController.php","line":165,"function":"updateAcl","class":"OCA\\Deck\\Service\\BoardService","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"updateAcl","class":"OCA\\Deck\\Controller\\BoardApiController","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhost
2020-04-18 11:16:04.082 26846-26846/it.niedermann.nextcloud.deck.dev D/DeckLog: onError() (IResponseCallback.java:21) -> com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException: HTTP request failed with HTTP status-code: 500
        at com.nextcloud.android.sso.api.AidlNetworkRequest.performNetworkRequest(AidlNetworkRequest.java:202)
        at com.nextcloud.android.sso.api.NextcloudAPI.performNetworkRequest(NextcloudAPI.java:119)
        at com.nextcloud.android.sso.api.NextcloudAPI.performRequest(NextcloudAPI.java:98)
        at com.nextcloud.android.sso.api.NextcloudAPI.lambda$performRequestObservable$0$NextcloudAPI(NextcloudAPI.java:86)
        at com.nextcloud.android.sso.api.-$$Lambda$NextcloudAPI$yhhE-DMCe81fXF-bhjup5Tra-6o.subscribe(Unknown Source:6)
        at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
        at io.reactivex.Observable.subscribe(Observable.java:12284)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalStateException: {"status":500,"message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","exception":{"\u0000*\u0000message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","\u0000Exception\u0000string":"","\u0000*\u0000code":0,"\u0000*\u0000file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","\u0000*\u0000line":283,"\u0000Exception\u0000trace":[{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","line":371,"function":"findOneQuery","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"],null,null]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/DeckMapper.php","line":45,"function":"findEntity","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"]]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/AclMapper.php","line":47,"function":"find","class":"OCA\\Deck\\Db\\DeckMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/PermissionService.php","line":139,"function":"findBoardId","class":"OCA\\Deck\\Db\\AclMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/BoardService.php","line":570,"function":"checkPermission","class":"OCA\\Deck\\Service\\PermissionService","type":"-\u003E","args":[{},"17",2]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Controller\/BoardApiController.php","line":165,"function":"updateAcl","class":"OCA\\Deck\\Service\\BoardService","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"updateAcl","class":"OCA\\Deck\\Controller\\BoardApiController","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhost
2020-04-18 11:16:04.088 26846-27300/it.niedermann.nextcloud.deck.dev D/DeckLog: onError() (IResponseCallback.java:21) -> com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException: HTTP request failed with HTTP status-code: 500
        at com.nextcloud.android.sso.api.AidlNetworkRequest.performNetworkRequest(AidlNetworkRequest.java:202)
        at com.nextcloud.android.sso.api.NextcloudAPI.performNetworkRequest(NextcloudAPI.java:119)
        at com.nextcloud.android.sso.api.NextcloudAPI.performRequest(NextcloudAPI.java:98)
        at com.nextcloud.android.sso.api.NextcloudAPI.lambda$performRequestObservable$0$NextcloudAPI(NextcloudAPI.java:86)
        at com.nextcloud.android.sso.api.-$$Lambda$NextcloudAPI$yhhE-DMCe81fXF-bhjup5Tra-6o.subscribe(Unknown Source:6)
        at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
        at io.reactivex.Observable.subscribe(Observable.java:12284)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalStateException: {"status":500,"message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","exception":{"\u0000*\u0000message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","\u0000Exception\u0000string":"","\u0000*\u0000code":0,"\u0000*\u0000file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","\u0000*\u0000line":283,"\u0000Exception\u0000trace":[{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","line":371,"function":"findOneQuery","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"],null,null]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/DeckMapper.php","line":45,"function":"findEntity","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"]]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/AclMapper.php","line":47,"function":"find","class":"OCA\\Deck\\Db\\DeckMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/PermissionService.php","line":139,"function":"findBoardId","class":"OCA\\Deck\\Db\\AclMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/BoardService.php","line":570,"function":"checkPermission","class":"OCA\\Deck\\Service\\PermissionService","type":"-\u003E","args":[{},"17",2]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Controller\/BoardApiController.php","line":165,"function":"updateAcl","class":"OCA\\Deck\\Service\\BoardService","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"updateAcl","class":"OCA\\Deck\\Controller\\BoardApiController","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhost
2020-04-18 11:16:04.093 26846-27301/it.niedermann.nextcloud.deck.dev D/DeckLog: onError() (IResponseCallback.java:21) -> com.nextcloud.android.sso.exceptions.NextcloudHttpRequestFailedException: HTTP request failed with HTTP status-code: 500
        at com.nextcloud.android.sso.api.AidlNetworkRequest.performNetworkRequest(AidlNetworkRequest.java:202)
        at com.nextcloud.android.sso.api.NextcloudAPI.performNetworkRequest(NextcloudAPI.java:119)
        at com.nextcloud.android.sso.api.NextcloudAPI.performRequest(NextcloudAPI.java:98)
        at com.nextcloud.android.sso.api.NextcloudAPI.lambda$performRequestObservable$0$NextcloudAPI(NextcloudAPI.java:86)
        at com.nextcloud.android.sso.api.-$$Lambda$NextcloudAPI$yhhE-DMCe81fXF-bhjup5Tra-6o.subscribe(Unknown Source:6)
        at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
        at io.reactivex.Observable.subscribe(Observable.java:12284)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
     Caused by: java.lang.IllegalStateException: {"status":500,"message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","exception":{"\u0000*\u0000message":"Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?\"; parameters Array\n(\n    [0] =\u003E 17\n)\n; limit \"\"; offset \"\"","\u0000Exception\u0000string":"","\u0000*\u0000code":0,"\u0000*\u0000file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","\u0000*\u0000line":283,"\u0000Exception\u0000trace":[{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/public\/AppFramework\/Db\/Mapper.php","line":371,"function":"findOneQuery","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"],null,null]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/DeckMapper.php","line":45,"function":"findEntity","class":"OCP\\AppFramework\\Db\\Mapper","type":"-\u003E","args":["SELECT * FROM `*PREFIX*deck_board_acl` WHERE `id` = ?",["17"]]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Db\/AclMapper.php","line":47,"function":"find","class":"OCA\\Deck\\Db\\DeckMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/PermissionService.php","line":139,"function":"findBoardId","class":"OCA\\Deck\\Db\\AclMapper","type":"-\u003E","args":["17"]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Service\/BoardService.php","line":570,"function":"checkPermission","class":"OCA\\Deck\\Service\\PermissionService","type":"-\u003E","args":[{},"17",2]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/apps\/deck\/lib\/Controller\/BoardApiController.php","line":165,"function":"updateAcl","class":"OCA\\Deck\\Service\\BoardService","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhosts\/example.com\/nextcloud.example.com\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"updateAcl","class":"OCA\\Deck\\Controller\\BoardApiController","type":"-\u003E","args":["17",false,false,false]},{"file":"\/var\/www\/vhost
2020-04-18 11:16:08.459 26846-26846/it.niedermann.nextcloud.deck.dev I/Choreographer: Skipped 258 frames!  The application may be doing too much work on its main thread.
```

Can you have a look please?