### PR TITLE
#478 ViewModels do not survive system initiated process death

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -362,10 +362,10 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 
     @Override
     protected void onStop() {
+        // Clean up zombie fragments in case of system initiated process death.
+        // See linked issues in https://github.com/stefan-niedermann/nextcloud-deck/issues/478
         for (Fragment fragment : getSupportFragmentManager().getFragments()) {
-            if (fragment instanceof StackFragment) {
-                getSupportFragmentManager().beginTransaction().remove(fragment).commit();
-            }
+            getSupportFragmentManager().beginTransaction().remove(fragment).commit();
         }
         super.onStop();
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -29,6 +29,7 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.util.Pair;
 import androidx.core.view.GravityCompat;
+import androidx.fragment.app.Fragment;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
@@ -357,6 +358,16 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
             overflowDrawable.setColorFilter(textColor, PorterDuff.Mode.SRC_ATOP);
             headerBinding.drawerAccountChooserToggle.setImageDrawable(overflowDrawable);
         }
+    }
+
+    @Override
+    protected void onStop() {
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            if (fragment instanceof StackFragment) {
+                getSupportFragmentManager().beginTransaction().remove(fragment).commit();
+            }
+        }
+        super.onStop();
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -14,6 +14,7 @@ import android.view.MenuItem;
 import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.tabs.TabLayout;
@@ -25,6 +26,10 @@ import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
+import it.niedermann.nextcloud.deck.ui.card.activities.CardActivityFragment;
+import it.niedermann.nextcloud.deck.ui.card.attachments.CardAttachmentsFragment;
+import it.niedermann.nextcloud.deck.ui.card.comments.CardCommentsFragment;
+import it.niedermann.nextcloud.deck.ui.card.details.CardDetailsFragment;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 import it.niedermann.nextcloud.deck.util.CardUtil;
 
@@ -257,6 +262,19 @@ public class EditActivity extends BrandedActivity {
         } else {
             super.finish();
         }
+    }
+
+    @Override
+    protected void onStop() {
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            if (fragment instanceof CardDetailsFragment
+                    || fragment instanceof CardAttachmentsFragment
+                    || fragment instanceof CardCommentsFragment
+                    || fragment instanceof CardActivityFragment) {
+                getSupportFragmentManager().beginTransaction().remove(fragment).commit();
+            }
+        }
+        super.onStop();
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -26,10 +26,6 @@ import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
-import it.niedermann.nextcloud.deck.ui.card.activities.CardActivityFragment;
-import it.niedermann.nextcloud.deck.ui.card.attachments.CardAttachmentsFragment;
-import it.niedermann.nextcloud.deck.ui.card.comments.CardCommentsFragment;
-import it.niedermann.nextcloud.deck.ui.card.details.CardDetailsFragment;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 import it.niedermann.nextcloud.deck.util.CardUtil;
 
@@ -266,13 +262,10 @@ public class EditActivity extends BrandedActivity {
 
     @Override
     protected void onStop() {
+        // Clean up zombie fragments in case of system initiated process death.
+        // See linked issues in https://github.com/stefan-niedermann/nextcloud-deck/issues/478
         for (Fragment fragment : getSupportFragmentManager().getFragments()) {
-            if (fragment instanceof CardDetailsFragment
-                    || fragment instanceof CardAttachmentsFragment
-                    || fragment instanceof CardCommentsFragment
-                    || fragment instanceof CardActivityFragment) {
-                getSupportFragmentManager().beginTransaction().remove(fragment).commit();
-            }
+            getSupportFragmentManager().beginTransaction().remove(fragment).commit();
         }
         super.onStop();
     }


### PR DESCRIPTION
Remove fragments onStop() to avoid zombie fragments after activity has been killed by Android and recreated by User