### PR TITLE
Fix #531 Issue with Glide SSO module

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherViewHolder.java
@@ -8,11 +8,13 @@ import androidx.core.util.Consumer;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.request.RequestOptions;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ItemAccountChooseBinding;
 import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.util.glide.SingleSignOnOriginHeader;
 
 import static it.niedermann.nextcloud.deck.util.DimensionUtil.dpToPx;
 
@@ -29,7 +31,7 @@ public class AccountSwitcherViewHolder extends RecyclerView.ViewHolder {
         binding.accountName.setText(account.getUserName());
         binding.accountHost.setText(Uri.parse(account.getUrl()).getHost());
         Glide.with(itemView.getContext())
-                .load(account.getAvatarUrl(dpToPx(binding.accountItemAvatar.getContext(), R.dimen.avatar_size)))
+                .load(new GlideUrl(account.getAvatarUrl(dpToPx(binding.accountItemAvatar.getContext(), R.dimen.avatar_size)), new SingleSignOnOriginHeader(account)))
                 .error(R.drawable.ic_person_grey600_24dp)
                 .apply(RequestOptions.circleCropTransform())
                 .into(binding.accountItemAvatar);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountViewHolder.java
@@ -9,11 +9,13 @@ import androidx.core.util.Consumer;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.request.RequestOptions;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ItemAccountChooseBinding;
 import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.util.glide.SingleSignOnOriginHeader;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
@@ -32,7 +34,7 @@ public class ManageAccountViewHolder extends RecyclerView.ViewHolder {
         binding.accountName.setText(account.getUserName());
         binding.accountHost.setText(Uri.parse(account.getUrl()).getHost());
         Glide.with(itemView.getContext())
-                .load(account.getAvatarUrl(dpToPx(binding.accountItemAvatar.getContext(), R.dimen.avatar_size)))
+                .load(new GlideUrl(account.getAvatarUrl(dpToPx(binding.accountItemAvatar.getContext(), R.dimen.avatar_size)), new SingleSignOnOriginHeader(account)))
                 .error(R.drawable.ic_person_grey600_24dp)
                 .apply(RequestOptions.circleCropTransform())
                 .into(binding.accountItemAvatar);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/glide/SingleSignOnOriginHeader.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/glide/SingleSignOnOriginHeader.java
@@ -1,0 +1,38 @@
+package it.niedermann.nextcloud.deck.util.glide;
+
+import androidx.annotation.NonNull;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.model.Headers;
+import com.bumptech.glide.load.model.LazyHeaders;
+import com.nextcloud.android.sso.helper.SingleAccountHelper;
+import com.nextcloud.android.sso.model.SingleSignOnAccount;
+
+import java.util.Map;
+
+import it.niedermann.nextcloud.deck.model.Account;
+
+public class SingleSignOnOriginHeader implements Headers {
+
+    private LazyHeaders headers;
+
+    /**
+     * Use this header and set the {@link SingleSignOnAccount} name property as value
+     * Format of the value needs to be
+     */
+    public static final String X_HEADER_SSO_ACCOUNT_NAME = "X-SSO-Account-Name";
+
+    /**
+     * Use this as {@link Headers} if you want to do a {@link Glide} request for an {@link SingleSignOnAccount} which is not set by {@link SingleAccountHelper} as current {@link SingleSignOnAccount}.
+     *
+     * @param account Account from which host the request should be fired
+     */
+    public SingleSignOnOriginHeader(@NonNull Account account) {
+        this.headers = new LazyHeaders.Builder().addHeader(X_HEADER_SSO_ACCOUNT_NAME, account.getName()).build();
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return this.headers.getHeaders();
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/glide/SingleSignOnStreamFetcher.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/glide/SingleSignOnStreamFetcher.java
@@ -8,6 +8,7 @@ import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.data.DataFetcher;
 import com.bumptech.glide.load.model.GlideUrl;
+import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.aidl.NextcloudRequest;
 import com.nextcloud.android.sso.api.NextcloudAPI;
 import com.nextcloud.android.sso.api.Response;
@@ -26,6 +27,8 @@ import java.util.Map;
 
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.api.GsonConfig;
+
+import static it.niedermann.nextcloud.deck.util.glide.SingleSignOnOriginHeader.X_HEADER_SSO_ACCOUNT_NAME;
 
 
 /**
@@ -48,12 +51,17 @@ public class SingleSignOnStreamFetcher implements DataFetcher<InputStream> {
 
     @Override
     public void loadData(@NonNull Priority priority, @NonNull final DataCallback<? super InputStream> callback) {
-        NextcloudAPI client = null;
+        NextcloudAPI client;
         try {
-            SingleSignOnAccount ssoAccount = SingleAccountHelper.getCurrentSingleSignOnAccount(context);
+            final SingleSignOnAccount ssoAccount;
+            if (url.getHeaders().containsKey(X_HEADER_SSO_ACCOUNT_NAME)) {
+                ssoAccount = AccountImporter.getSingleSignOnAccount(context, url.getHeaders().get(X_HEADER_SSO_ACCOUNT_NAME));
+            } else {
+                ssoAccount = SingleAccountHelper.getCurrentSingleSignOnAccount(context);
+            }
             client = INITIALIZED_APIs.get(ssoAccount.name);
             boolean didInitialize = false;
-            if (client == null){
+            if (client == null) {
                 client = new NextcloudAPI(context, ssoAccount, GsonConfig.getGson(), new NextcloudAPI.ApiConnectedListener() {
                     @Override
                     public void onConnected() {
@@ -69,7 +77,7 @@ public class SingleSignOnStreamFetcher implements DataFetcher<InputStream> {
                 didInitialize = true;
             }
 
-            NextcloudRequest.Builder requestBuilder = null;
+            NextcloudRequest.Builder requestBuilder;
             try {
                 requestBuilder = new NextcloudRequest.Builder()
                         .setMethod(METHOD_GET)
@@ -86,7 +94,7 @@ public class SingleSignOnStreamFetcher implements DataFetcher<InputStream> {
             } catch (MalformedURLException e) {
                 callback.onLoadFailed(e);
             } catch (TokenMismatchException e) {
-                if (!didInitialize){
+                if (!didInitialize) {
                     DeckLog.warn("SSO Glide loader failed with TokenMismatchException, trying to re-initialize...");
                     client.stop();
                     INITIALIZED_APIs.remove(ssoAccount.name);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/glide/SingleSignOnStreamFetcher.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/glide/SingleSignOnStreamFetcher.java
@@ -84,7 +84,9 @@ public class SingleSignOnStreamFetcher implements DataFetcher<InputStream> {
                         .setUrl(url.toURL().getPath());
                 Map<String, List<String>> header = new HashMap<>();
                 for (Map.Entry<String, String> headerEntry : url.getHeaders().entrySet()) {
-                    header.put(headerEntry.getKey(), Collections.singletonList(headerEntry.getValue()));
+                    if(!X_HEADER_SSO_ACCOUNT_NAME.equals(headerEntry.getKey())) {
+                        header.put(headerEntry.getKey(), Collections.singletonList(headerEntry.getValue()));
+                    }
                 }
                 requestBuilder.setHeader(header);
                 NextcloudRequest nextcloudRequest = requestBuilder.build();


### PR DESCRIPTION
Decided to use option 4 (Pass down information in Header) from https://github.com/stefan-niedermann/nextcloud-deck/issues/531 because

- Little effort
- Actual request parameters are not touched
- No third party dependencies
- No magic: If one wants to load an avatar from a host which is **not** the current account, then explicitly pass the target account down to `Glide` 