### PR TITLE
Reduce label padding

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelChip.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelChip.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
-import android.text.TextUtils;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -16,6 +15,8 @@ import com.google.android.material.chip.Chip;
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.util.ColorUtil;
+
+import static android.text.TextUtils.TruncateAt.MIDDLE;
 
 @SuppressLint("ViewConstructor")
 public class LabelChip extends Chip {
@@ -38,16 +39,12 @@ public class LabelChip extends Chip {
         setChipMinHeight(0);
         setPadding(0, gutter, 0, gutter);
         setChipStartPadding(gutter);
-        setIconStartPadding(0);
-        setIconEndPadding(0);
         setTextStartPadding(gutter);
         setTextEndPadding(gutter);
-        setCloseIconStartPadding(0);
-        setCloseIconEndPadding(0);
         setChipEndPadding(gutter);
 
         setText(label.getTitle());
-        setEllipsize(TextUtils.TruncateAt.END);
+        setEllipsize(MIDDLE);
 
         try {
             int labelColor = Color.parseColor("#" + label.getColor());

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelChip.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelChip.java
@@ -37,8 +37,14 @@ public class LabelChip extends Chip {
         setMinHeight(0);
         setChipMinHeight(0);
         setPadding(0, gutter, 0, gutter);
-        setChipStartPadding(0);
-        setChipEndPadding(0);
+        setChipStartPadding(gutter);
+        setIconStartPadding(0);
+        setIconEndPadding(0);
+        setTextStartPadding(gutter);
+        setTextEndPadding(gutter);
+        setCloseIconStartPadding(0);
+        setCloseIconEndPadding(0);
+        setChipEndPadding(gutter);
 
         setText(label.getTitle());
         setEllipsize(TextUtils.TruncateAt.END);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelChip.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelChip.java
@@ -8,12 +8,12 @@ import android.text.TextUtils;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Px;
 
 import com.google.android.flexbox.FlexboxLayout;
 import com.google.android.material.chip.Chip;
 
 import it.niedermann.nextcloud.deck.DeckLog;
-import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.util.ColorUtil;
 
@@ -22,7 +22,7 @@ public class LabelChip extends Chip {
 
     private final Label label;
 
-    public LabelChip(@NonNull Context context, @NonNull Label label) {
+    public LabelChip(@NonNull Context context, @NonNull Label label, @Px int gutter) {
         super(context);
         this.label = label;
 
@@ -31,9 +31,14 @@ public class LabelChip extends Chip {
                 ViewGroup.LayoutParams.WRAP_CONTENT
         );
 
-        params.setMargins(0, 0, Math.round(context.getResources().getDimension(R.dimen.spacer_1x)), 0);
+        params.setMargins(0, 0, gutter, 0);
         setLayoutParams(params);
         setEnsureMinTouchTargetSize(false);
+        setMinHeight(0);
+        setChipMinHeight(0);
+        setPadding(0, gutter, 0, gutter);
+        setChipStartPadding(0);
+        setChipEndPadding(0);
 
         setText(label.getTitle());
         setEllipsize(TextUtils.TruncateAt.END);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelLayout.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/LabelLayout.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Px;
 
 import com.google.android.flexbox.FlexboxLayout;
 
@@ -11,14 +12,20 @@ import java.util.LinkedList;
 import java.util.List;
 
 import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Label;
+
+import static it.niedermann.nextcloud.deck.util.DimensionUtil.dpToPx;
 
 public class LabelLayout extends FlexboxLayout {
 
+    @Px
+    private int gutter;
     private List<LabelChip> chipList = new LinkedList<>();
 
     public LabelLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
+        this.gutter = dpToPx(context, R.dimen.spacer_1hx);
     }
 
     /**
@@ -75,7 +82,7 @@ public class LabelLayout extends FlexboxLayout {
                     continue labelList;
                 }
             }
-            LabelChip chip = new LabelChip(getContext(), label);
+            LabelChip chip = new LabelChip(getContext(), label, gutter);
             addView(chip);
             chipList.add(chip);
         }


### PR DESCRIPTION
This is the attempt to fix this issue https://github.com/nextcloud/deck/issues/1872 for the Android app.

We reduce the padding in the board overview, but keep the labels everywhere exactly as they are now (because in other places they are likely touch targets and therefore need to have a certain size).


- **Left:** Old and busted
- **Right:** New hotness

| 1 | 1 |
| --- | --- |
| ![alt](https://user-images.githubusercontent.com/4741199/85029723-e2f52880-b17c-11ea-9cd5-9dec191ab431.png) | ![new](https://user-images.githubusercontent.com/4741199/85029716-e25c9200-b17c-11ea-95b6-7ee40cdd1997.png) |