### PR TITLE
Show progress of incoming file shares in a dialog

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/SelectCardActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/SelectCardActivity.java
@@ -134,7 +134,7 @@ public class SelectCardActivity extends MainActivity implements SelectCardListen
                         liveData.observe(SelectCardActivity.this, (next) -> {
                             if (liveData.hasError()) {
                                 if (liveData.getError() instanceof NextcloudHttpRequestFailedException && ((NextcloudHttpRequestFailedException) liveData.getError()).getStatusCode() == HTTP_CONFLICT) {
-                                    shareProgressViewModel.addAlreadyExistingAttachment(tempFile.getName());
+                                    shareProgressViewModel.addDuplicateAttachment(tempFile.getName());
                                 } else {
                                     shareProgressViewModel.addException(liveData.getError());
                                 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentAdapter.java
@@ -150,6 +150,10 @@ public class CardAttachmentAdapter extends RecyclerView.Adapter<AttachmentViewHo
                     holder.getPreview().setImageResource(R.drawable.ic_music_note_grey600_24dp);
                 } else if (MimeTypeUtil.isVideo(attachment.getMimetype())) {
                     holder.getPreview().setImageResource(R.drawable.ic_local_movies_grey600_24dp);
+                } else if (MimeTypeUtil.isPdf(attachment.getMimetype())) {
+                    holder.getPreview().setImageResource(R.drawable.ic_baseline_picture_as_pdf_24);
+                } else {
+                    holder.getPreview().setImageResource(R.drawable.ic_attach_file_grey600_24dp);
                 }
 
                 if (cardRemoteId != null) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentAdapter.java
@@ -124,6 +124,7 @@ public class CardAttachmentAdapter extends RecyclerView.Adapter<AttachmentViewHo
                 holder.getPreview().setImageResource(R.drawable.ic_image_grey600_24dp);
                 Glide.with(context)
                         .load(uri)
+                        .placeholder(R.drawable.ic_image_grey600_24dp)
                         .error(R.drawable.ic_image_grey600_24dp)
                         .into(holder.getPreview());
                 holder.itemView.setOnClickListener((v) -> {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
@@ -56,7 +56,7 @@ public class ShareProgressDialogFragment extends BrandedDialogFragment {
             binding.progressText.setText(getString(R.string.progress_count, progress, viewModel.getMaxValue()));
             final Integer currentMaxValue = viewModel.getMaxValue();
             if (currentMaxValue != null && progress >= currentMaxValue) {
-                if (!viewModel.hasExceptions() && !viewModel.hasAlreadyExistingAttachments()) {
+                if (!viewModel.hasExceptions() && !viewModel.hasAlreadyDuplicateAttachments()) {
                     Toast.makeText(requireContext(), getString(R.string.share_success, String.valueOf(currentMaxValue), viewModel.targetCardTitle), Toast.LENGTH_LONG).show();
                     dismiss();
                 }
@@ -81,7 +81,7 @@ public class ShareProgressDialogFragment extends BrandedDialogFragment {
             }
         });
 
-        viewModel.getAlreadyExistingAttachments().observe(requireActivity(), (duplicates) -> {
+        viewModel.getDuplicateAttachments().observe(requireActivity(), (duplicates) -> {
             final int duplicatesCount = duplicates.size();
             if (duplicatesCount > 0) {
                 final LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
@@ -1,0 +1,86 @@
+package it.niedermann.nextcloud.deck.ui.sharetarget;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.lifecycle.ViewModelProvider;
+
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.databinding.DialogShareProgressBinding;
+import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
+import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
+import it.niedermann.nextcloud.deck.util.ExceptionUtil;
+
+import static android.graphics.PorterDuff.Mode;
+
+public class ShareProgressDialogFragment extends BrandedDialogFragment {
+
+    private DialogShareProgressBinding binding;
+    private ShareProgressViewModel viewModel;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        viewModel = new ViewModelProvider(requireActivity()).get(ShareProgressViewModel.class);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        binding = DialogShareProgressBinding.inflate(requireActivity().getLayoutInflater());
+
+        return new AlertDialog.Builder(requireContext())
+                .setView(binding.getRoot())
+                .create();
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        viewModel.getMax().observe(requireActivity(), (nextMax) -> binding.progress.setMax(nextMax));
+        viewModel.getProgress().observe(requireActivity(), (progress) -> {
+            binding.progress.setProgress(progress);
+            binding.progressText.setText(getString(R.string.progress_count, progress, viewModel.getMaxValue()));
+        });
+
+        viewModel.getExceptions().observe(requireActivity(), (exceptions) -> {
+            if (exceptions.size() > 0) {
+                final StringBuilder debugInfos = new StringBuilder();
+                for (Throwable exception : exceptions) {
+                    debugInfos.append(ExceptionUtil.getDebugInfos(requireContext(), exception, null));
+                }
+                binding.stacktrace.setText(debugInfos);
+                binding.stacktraceContainer.setVisibility(View.VISIBLE);
+            } else {
+                binding.stacktraceContainer.setVisibility(View.GONE);
+            }
+        });
+    }
+
+    @Override
+    public void onDismiss(@NonNull DialogInterface dialog) {
+        requireActivity().finish();
+    }
+
+    @Override
+    public void onCancel(@NonNull DialogInterface dialog) {
+        requireActivity().finish();
+    }
+
+    public static ShareProgressDialogFragment newInstance() {
+        return new ShareProgressDialogFragment();
+    }
+
+    @Override
+    public void applyBrand(int mainColor, int textColor) {
+        binding.progress.getProgressDrawable().setColorFilter(
+                BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor), Mode.SRC_IN);
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressViewModel.java
@@ -1,0 +1,61 @@
+package it.niedermann.nextcloud.deck.ui.sharetarget;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+
+public class ShareProgressViewModel extends ViewModel {
+
+    @NonNull
+    private MutableLiveData<List<Throwable>> exceptions = new MutableLiveData<>(new ArrayList<>());
+    @NonNull
+    private MutableLiveData<Integer> max = new MutableLiveData<>(0);
+    @NonNull
+    private MutableLiveData<Integer> progress = new MutableLiveData<>(0);
+
+    public void postMax(int max) {
+        this.max.postValue(max);
+    }
+
+    public LiveData<Integer> getMax() {
+        return this.max;
+    }
+
+    public Integer getMaxValue() {
+        return this.max.getValue();
+    }
+
+    public void increaseProgress() {
+        Integer currentValue = this.progress.getValue();
+        if (currentValue == null) {
+            this.progress.postValue(0);
+        } else {
+            this.progress.postValue(currentValue + 1);
+        }
+    }
+
+    public LiveData<Integer> getProgress() {
+        return this.progress;
+    }
+
+    public void addException(Throwable exception) {
+        DeckLog.logError(exception);
+        List<Throwable> exceptionList = this.exceptions.getValue();
+        if (exceptionList == null) {
+            exceptionList = new ArrayList<>();
+        }
+        exceptionList.add(exception);
+        this.exceptions.postValue(exceptionList);
+        increaseProgress();
+    }
+
+    public LiveData<List<Throwable>> getExceptions() {
+        return this.exceptions;
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressViewModel.java
@@ -12,15 +12,18 @@ import it.niedermann.nextcloud.deck.DeckLog;
 
 public class ShareProgressViewModel extends ViewModel {
 
+    public String targetCardTitle = "";
     @NonNull
     private MutableLiveData<List<Throwable>> exceptions = new MutableLiveData<>(new ArrayList<>());
     @NonNull
-    private MutableLiveData<Integer> max = new MutableLiveData<>(0);
+    private MutableLiveData<List<String>> alreadyExistingAttachments = new MutableLiveData<>(new ArrayList<>());
+    @NonNull
+    private MutableLiveData<Integer> max = new MutableLiveData<>();
     @NonNull
     private MutableLiveData<Integer> progress = new MutableLiveData<>(0);
 
-    public void postMax(int max) {
-        this.max.postValue(max);
+    public void setMax(int max) {
+        this.max.setValue(max);
     }
 
     public LiveData<Integer> getMax() {
@@ -32,16 +35,38 @@ public class ShareProgressViewModel extends ViewModel {
     }
 
     public void increaseProgress() {
-        Integer currentValue = this.progress.getValue();
+        final Integer currentValue = this.progress.getValue();
         if (currentValue == null) {
-            this.progress.postValue(0);
+            this.progress.setValue(0);
         } else {
-            this.progress.postValue(currentValue + 1);
+            this.progress.setValue(currentValue + 1);
         }
     }
 
     public LiveData<Integer> getProgress() {
         return this.progress;
+    }
+
+    public void addAlreadyExistingAttachment(String fileName) {
+        List<String> fileNames = this.alreadyExistingAttachments.getValue();
+        if (fileNames == null) {
+            fileNames = new ArrayList<>();
+        }
+        fileNames.add(fileName);
+        this.alreadyExistingAttachments.setValue(fileNames);
+        increaseProgress();
+    }
+
+    public boolean hasAlreadyExistingAttachments() {
+        List<String> alreadyExistingAttachments = this.alreadyExistingAttachments.getValue();
+        if (alreadyExistingAttachments == null) {
+            return false;
+        }
+        return alreadyExistingAttachments.size() > 0;
+    }
+
+    public LiveData<List<String>> getAlreadyExistingAttachments() {
+        return this.alreadyExistingAttachments;
     }
 
     public void addException(Throwable exception) {
@@ -51,8 +76,16 @@ public class ShareProgressViewModel extends ViewModel {
             exceptionList = new ArrayList<>();
         }
         exceptionList.add(exception);
-        this.exceptions.postValue(exceptionList);
+        this.exceptions.setValue(exceptionList);
         increaseProgress();
+    }
+
+    public boolean hasExceptions() {
+        List<Throwable> exceptions = this.exceptions.getValue();
+        if (exceptions == null) {
+            return false;
+        }
+        return exceptions.size() > 0;
     }
 
     public LiveData<List<Throwable>> getExceptions() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressViewModel.java
@@ -12,11 +12,12 @@ import it.niedermann.nextcloud.deck.DeckLog;
 
 public class ShareProgressViewModel extends ViewModel {
 
+    @NonNull
     public String targetCardTitle = "";
     @NonNull
     private MutableLiveData<List<Throwable>> exceptions = new MutableLiveData<>(new ArrayList<>());
     @NonNull
-    private MutableLiveData<List<String>> alreadyExistingAttachments = new MutableLiveData<>(new ArrayList<>());
+    private MutableLiveData<List<String>> duplicateAttachments = new MutableLiveData<>(new ArrayList<>());
     @NonNull
     private MutableLiveData<Integer> max = new MutableLiveData<>();
     @NonNull
@@ -47,26 +48,26 @@ public class ShareProgressViewModel extends ViewModel {
         return this.progress;
     }
 
-    public void addAlreadyExistingAttachment(String fileName) {
-        List<String> fileNames = this.alreadyExistingAttachments.getValue();
+    public void addDuplicateAttachment(String fileName) {
+        List<String> fileNames = this.duplicateAttachments.getValue();
         if (fileNames == null) {
             fileNames = new ArrayList<>();
         }
         fileNames.add(fileName);
-        this.alreadyExistingAttachments.setValue(fileNames);
+        this.duplicateAttachments.setValue(fileNames);
         increaseProgress();
     }
 
-    public boolean hasAlreadyExistingAttachments() {
-        List<String> alreadyExistingAttachments = this.alreadyExistingAttachments.getValue();
-        if (alreadyExistingAttachments == null) {
+    public boolean hasAlreadyDuplicateAttachments() {
+        List<String> duplicateAttachments = this.duplicateAttachments.getValue();
+        if (duplicateAttachments == null) {
             return false;
         }
-        return alreadyExistingAttachments.size() > 0;
+        return duplicateAttachments.size() > 0;
     }
 
-    public LiveData<List<String>> getAlreadyExistingAttachments() {
-        return this.alreadyExistingAttachments;
+    public LiveData<List<String>> getDuplicateAttachments() {
+        return this.duplicateAttachments;
     }
 
     public void addException(Throwable exception) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/MimeTypeUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/MimeTypeUtil.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 public class MimeTypeUtil {
 
     public static final String TEXT_PLAIN = "text/plain";
-    public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+    public static final String APPLICATION_PDF = "application/pdf";
 
     /**
      * @return 'True' if the mime type defines image
@@ -34,5 +34,12 @@ public class MimeTypeUtil {
      */
     public static boolean isText(String mimeType) {
         return mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("text/");
+    }
+
+    /**
+     * @return 'True' if mime type defines pdf
+     */
+    public static boolean isPdf(String mimeType) {
+        return APPLICATION_PDF.equals(mimeType.toLowerCase(Locale.ROOT));
     }
 }

--- a/app/src/main/res/drawable/ic_baseline_picture_as_pdf_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_picture_as_pdf_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#757575"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM11.5,9.5c0,0.83 -0.67,1.5 -1.5,1.5L9,11v2L7.5,13L7.5,7L10,7c0.83,0 1.5,0.67 1.5,1.5v1zM16.5,11.5c0,0.83 -0.67,1.5 -1.5,1.5h-2.5L12.5,7L15,7c0.83,0 1.5,0.67 1.5,1.5v3zM20.5,8.5L19,8.5v1h1.5L20.5,11L19,11v2h-1.5L17.5,7h3v1.5zM9,9.5h1v-1L9,8.5v1zM4,6L2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6zM14,11.5h1v-3h-1v3z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_share_progress.xml
+++ b/app/src/main/res/layout/dialog_share_progress.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/spacer_3x"
+    android:paddingStart="@dimen/spacer_2x"
+    android:paddingEnd="@dimen/spacer_2x">
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:max="100"
+        android:progress="45" />
+
+    <TextView
+        android:id="@+id/progressText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/spacer_1x"
+        android:textAppearance="?attr/textAppearanceBody1"
+        tools:text="3 of 5" />
+
+    <HorizontalScrollView
+        android:id="@+id/stacktraceContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/spacer_2x"
+        android:layout_marginBottom="@dimen/spacer_2x"
+        android:layout_weight="1"
+        android:background="@color/bg_highlighted"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/stacktrace"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/spacer_1x"
+            android:textIsSelectable="true"
+            android:typeface="monospace"
+            tools:text="@string/android_get_accounts_permission_not_granted_exception_message" />
+    </HorizontalScrollView>
+</LinearLayout>
+

--- a/app/src/main/res/layout/dialog_share_progress.xml
+++ b/app/src/main/res/layout/dialog_share_progress.xml
@@ -25,25 +25,53 @@
         android:textAppearance="?attr/textAppearanceBody1"
         tools:text="3 of 5" />
 
-    <HorizontalScrollView
-        android:id="@+id/stacktraceContainer"
+    <LinearLayout
+        android:id="@+id/errors"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacer_2x"
-        android:layout_marginBottom="@dimen/spacer_2x"
-        android:layout_weight="1"
-        android:background="@color/bg_highlighted"
+        android:orientation="horizontal"
         android:visibility="gone"
         tools:visibility="visible">
 
         <TextView
-            android:id="@+id/stacktrace"
+            android:id="@+id/errorCounter"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            tools:text="4 errors while uploading attachments" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/errorReportButton"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="@dimen/spacer_1x"
-            android:textIsSelectable="true"
-            android:typeface="monospace"
-            tools:text="@string/android_get_accounts_permission_not_granted_exception_message" />
-    </HorizontalScrollView>
+            android:gravity="end"
+            android:text="@string/simple_report" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/duplicatesContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacer_2x"
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/attachment_already_exists"
+            android:textAppearance="?attr/textAppearanceBody1" />
+
+        <LinearLayout
+            android:id="@+id/duplicates"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacer_1x"
+            android:orientation="vertical" />
+    </LinearLayout>
 </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,4 +271,9 @@
     <string name="append_text_to_description">Append to description</string>
     <string name="add_text_as_comment">Add as comment</string>
     <string name="progress_count">%1$d of %2$d</string>
+    <plurals name="progress_error_count">
+        <item quantity="one">%1$d error while uploading.</item>
+        <item quantity="other">%1$d errors while uploading</item>
+    </plurals>
+    <string name="simple_report">Report</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,4 +270,5 @@
     <string name="error_while_uploading_attachment">Error while uploading attachment: %1$s</string>
     <string name="append_text_to_description">Append to description</string>
     <string name="add_text_as_comment">Add as comment</string>
+    <string name="progress_count">%1$d of %2$d</string>
 </resources>

--- a/app/src/test/java/it/niedermann/nextcloud/deck/MimeTypeUtilTest.java
+++ b/app/src/test/java/it/niedermann/nextcloud/deck/MimeTypeUtilTest.java
@@ -84,5 +84,21 @@ public class MimeTypeUtilTest {
         }
     }
 
+    @Test
+    public void isPdf() {
+        final String[] validMimeTypes = new String[]{
+                "application/pdf", "APPLICATION/PDF", "Application/Pdf"
+        };
+        final String[] invalidMimeTypes = new String[]{
+                "audio/jpg", "img/jpg", "application/octet-stream", "app/pdf"
+        };
 
+        for (String validMimeType : validMimeTypes) {
+            assertTrue("Expecting " + validMimeType + " to be a valid text mimetype", MimeTypeUtil.isPdf(validMimeType));
+        }
+
+        for (String invalidMimeType : invalidMimeTypes) {
+            assertFalse("Expecting " + invalidMimeType + " to be an invalid text mimetype", MimeTypeUtil.isPdf(invalidMimeType));
+        }
+    }
 }


### PR DESCRIPTION
# ToDo

- [x] When sharing many files, the progress stops at `progress - 1` even though all attachments have been uploaded successfully.
- [x] Make errors discoverable
- [x] Treat duplicate attachments special and do not mark them as simple errors

![grafik](https://user-images.githubusercontent.com/4741199/85522395-e289e100-b605-11ea-96ef-d5a2872f7566.png)
