### PR TITLE
#525 Adjust design to new style of Nextcloud app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,20 +70,17 @@
         <activity
             android:name=".ui.archivedcards.ArchivedCardsActvitiy"
             android:label="@string/archived_cards"
-            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity"
-            android:theme="@style/AppTheme" />
+            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity" />
 
         <activity
             android:name=".ui.archivedboards.ArchivedBoardsActvitiy"
             android:label="@string/archived_boards"
-            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity"
-            android:theme="@style/AppTheme" />
+            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity"  />
 
         <activity
             android:name=".ui.card.EditActivity"
             android:label="@string/edit"
-            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity"
-            android:theme="@style/AppTheme" />
+            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity" />
 
         <activity
             android:name=".ui.attachments.AttachmentsActivity"
@@ -94,19 +91,16 @@
         <activity
             android:name=".ui.settings.SettingsActivity"
             android:label="@string/simple_settings"
-            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity"
-            android:theme="@style/AppTheme" />
+            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity" />
 
         <activity
             android:name=".ui.ImportAccountActivity"
-            android:label="@string/app_name"
-            android:theme="@style/AppTheme" />
+            android:label="@string/app_name" />
 
         <activity
             android:name=".ui.preparecreate.PrepareCreateActivity"
             android:description="@string/add_a_new_card_using_the_button"
-            android:label="@string/add_card"
-            android:theme="@style/AppTheme">
+            android:label="@string/add_card" >
 
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
@@ -118,13 +112,11 @@
         <activity
             android:name=".ui.about.AboutActivity"
             android:label="@string/about"
-            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity"
-            android:theme="@style/AppTheme" />
+            android:parentActivityName="it.niedermann.nextcloud.deck.ui.MainActivity" />
 
         <activity
             android:name=".ui.PushNotificationActivity"
-            android:label="@string/app_name"
-            android:theme="@style/AppTheme">
+            android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>

--- a/app/src/main/java/it/niedermann/nextcloud/deck/Application.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/Application.java
@@ -66,7 +66,7 @@ public class Application extends android.app.Application {
         if (Application.isBrandingEnabled(context)) {
             SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
             DeckLog.log("--- Read: shared_preference_theme_main");
-            return sharedPreferences.getInt(context.getString(R.string.shared_preference_theme_main), context.getApplicationContext().getResources().getColor(R.color.primary));
+            return sharedPreferences.getInt(context.getString(R.string.shared_preference_theme_main), context.getApplicationContext().getResources().getColor(R.color.defaultBrand));
         } else {
             return context.getResources().getColor(R.color.primary);
         }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/Application.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/Application.java
@@ -2,7 +2,6 @@ package it.niedermann.nextcloud.deck;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Color;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -73,28 +72,14 @@ public class Application extends android.app.Application {
         }
     }
 
-    @ColorInt
-    public static int readBrandTextColor(@NonNull Context context) {
-        if (isBrandingEnabled(context)) {
-            SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-            DeckLog.log("--- Read: shared_preference_theme_text");
-            return sharedPreferences.getInt(context.getString(R.string.shared_preference_theme_text), context.getApplicationContext().getResources().getColor(android.R.color.white));
-        } else {
-            return Color.WHITE;
-        }
-    }
-
-    public static void saveBrandColors(@NonNull Context context, @ColorInt int mainColor, @ColorInt int textColor) {
+    public static void saveBrandColors(@NonNull Context context, @ColorInt int mainColor) {
         if (isBrandingEnabled(context) && context instanceof BrandedActivity) {
             final BrandedActivity activity = (BrandedActivity) context;
-            activity.applyBrand(mainColor, textColor);
-            BrandedActivity.applyBrandToStatusbar(activity.getWindow(), mainColor, textColor);
+            activity.applyBrand(mainColor);
         }
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
         DeckLog.log("--- Write: shared_preference_theme_main" + " | " + mainColor);
-        DeckLog.log("--- Write: shared_preference_theme_text" + " | " + textColor);
         editor.putInt(context.getString(R.string.shared_preference_theme_main), mainColor);
-        editor.putInt(context.getString(R.string.shared_preference_theme_text), textColor);
         editor.apply();
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/Application.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/Application.java
@@ -24,7 +24,7 @@ public class Application extends android.app.Application {
 
     @Override
     public void onCreate() {
-        setAppTheme(getAppTheme(getApplicationContext()));
+        setAppTheme(isDarkTheme(getApplicationContext()));
         super.onCreate();
         AndroidThreeTen.init(this);
     }
@@ -47,7 +47,7 @@ public class Application extends android.app.Application {
         setDefaultNightMode(darkTheme ? MODE_NIGHT_YES : MODE_NIGHT_NO);
     }
 
-    public static boolean getAppTheme(@NonNull Context context) {
+    public static boolean isDarkTheme(@NonNull Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         return prefs.getBoolean(context.getString(R.string.pref_key_dark_theme), false);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DeckDatabase.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DeckDatabase.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.Cursor;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
@@ -205,7 +206,14 @@ public abstract class DeckDatabase extends RoomDatabase {
                 .addMigrations(new Migration(14, 15) {
                     @Override
                     public void migrate(@NonNull SupportSQLiteDatabase database) {
+                        // https://github.com/stefan-niedermann/nextcloud-deck/issues/570
                         SyncWorker.update(context);
+                        // https://github.com/stefan-niedermann/nextcloud-deck/issues/525
+                        PreferenceManager
+                                .getDefaultSharedPreferences(context)
+                                .edit()
+                                .remove("it.niedermann.nextcloud.deck.theme_text")
+                                .apply();
                     }
                 })
                 .fallbackToDestructiveMigration()

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/ImportAccountActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/ImportAccountActivity.java
@@ -4,13 +4,17 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteConstraintException;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.preference.PreferenceManager;
 
 import com.nextcloud.android.sso.AccountImporter;
@@ -81,6 +85,12 @@ public class ImportAccountActivity extends AppCompatActivity {
                 AccountImporter.requestAndroidAccountPermissionsAndPickAccount(this);
             }
         });
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            Drawable wrapDrawable = DrawableCompat.wrap(binding.progressCircular.getIndeterminateDrawable());
+            DrawableCompat.setTint(wrapDrawable, ContextCompat.getColor(this, R.color.defaultBrand));
+            binding.progressCircular.setIndeterminateDrawable(DrawableCompat.unwrap(wrapDrawable));
+        }
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -26,7 +26,6 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatDelegate;
-import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.util.Pair;
 import androidx.core.view.GravityCompat;
@@ -176,7 +175,6 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
         setSupportActionBar(binding.toolbar);
 
         final ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, binding.drawerLayout, binding.toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
-        toggle.getDrawerArrowDrawable().setColor(ContextCompat.getColor(this, R.color.accent));
         binding.drawerLayout.addDrawerListener(toggle);
         toggle.syncState();
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -413,7 +413,6 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 
     @Override
     public void applyBrand(@ColorInt int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
         applyBrandToPrimaryTabLayout(mainColor, binding.stackTitles);
         applyBrandToFAB(mainColor, binding.fab);
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -26,6 +26,7 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.util.Pair;
 import androidx.core.view.GravityCompat;
@@ -121,7 +122,6 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
     protected static final int ACTIVITY_SETTINGS = 2;
     public static final int ACTIVITY_MANAGE_ACCOUNTS = 4;
 
-    private ActionBarDrawerToggle toggle;
     @NonNull
     protected List<Account> accountsList = new ArrayList<>();
     protected SyncManager syncManager;
@@ -175,7 +175,8 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 
         setSupportActionBar(binding.toolbar);
 
-        toggle = new ActionBarDrawerToggle(this, binding.drawerLayout, binding.toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
+        final ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, binding.drawerLayout, binding.toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
+        toggle.getDrawerArrowDrawable().setColor(ContextCompat.getColor(this, R.color.accent));
         binding.drawerLayout.addDrawerListener(toggle);
         toggle.syncState();
 
@@ -419,7 +420,6 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
         applyBrandToFAB(mainColor, binding.fab);
 
 
-
         // Is null as soon as the avatar has been set
 //        @Nullable
 //        Drawable accountSwitcherDrawable = binding.accountSwitcher.getDrawable();
@@ -427,7 +427,6 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 //            DrawableCompat.setTint(accountSwitcherDrawable, textColor);
 //        }
         DrawableCompat.setTint(headerBinding.logo.getDrawable(), ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
-
         headerBinding.headerView.setBackgroundColor(mainColor);
         headerBinding.appName.setTextColor(ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -95,6 +95,7 @@ import it.niedermann.nextcloud.deck.ui.stack.EditStackListener;
 import it.niedermann.nextcloud.deck.ui.stack.OnScrollListener;
 import it.niedermann.nextcloud.deck.ui.stack.StackAdapter;
 import it.niedermann.nextcloud.deck.ui.stack.StackFragment;
+import it.niedermann.nextcloud.deck.util.ColorUtil;
 import it.niedermann.nextcloud.deck.util.DrawerMenuUtil;
 
 import static android.graphics.Color.parseColor;
@@ -120,6 +121,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
     protected static final int ACTIVITY_SETTINGS = 2;
     public static final int ACTIVITY_MANAGE_ACCOUNTS = 4;
 
+    private ActionBarDrawerToggle toggle;
     @NonNull
     protected List<Account> accountsList = new ArrayList<>();
     protected SyncManager syncManager;
@@ -173,7 +175,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 
         setSupportActionBar(binding.toolbar);
 
-        final ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, binding.drawerLayout, binding.toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
+        toggle = new ActionBarDrawerToggle(this, binding.drawerLayout, binding.toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
         binding.drawerLayout.addDrawerListener(toggle);
         toggle.syncState();
 
@@ -191,7 +193,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
         }).observe(this, (List<Account> accounts) -> {
             if (accounts == null || accounts.size() == 0) {
                 // Last account has been deleted.  hasAccounts LiveData will handle this, but we make sure, that branding is reset.
-                Application.saveBrandColors(this, getResources().getColor(R.color.primary), Color.WHITE);
+                Application.saveBrandColors(this, getResources().getColor(R.color.primary));
                 return;
             }
 
@@ -229,7 +231,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                 SingleAccountHelper.setCurrentAccount(getApplicationContext(), mainViewModel.getCurrentAccount().getName());
                 syncManager = new SyncManager(this);
 
-                Application.saveBrandColors(this, parseColor(mainViewModel.getCurrentAccount().getColor()), parseColor(mainViewModel.getCurrentAccount().getTextColor()));
+                Application.saveBrandColors(this, parseColor(mainViewModel.getCurrentAccount().getColor()));
                 Application.saveCurrentAccountId(this, mainViewModel.getCurrentAccount().getId());
                 if (mainViewModel.getCurrentAccount().isMaintenanceEnabled()) {
                     refreshCapabilities(mainViewModel.getCurrentAccount());
@@ -411,10 +413,12 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
     }
 
     @Override
-    public void applyBrand(@ColorInt int mainColor, @ColorInt int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
-        applyBrandToPrimaryTabLayout(mainColor, textColor, binding.stackTitles);
-        applyBrandToFAB(mainColor, textColor, binding.fab);
+    public void applyBrand(@ColorInt int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        applyBrandToPrimaryTabLayout(mainColor, binding.stackTitles);
+        applyBrandToFAB(mainColor, binding.fab);
+
+
 
         // Is null as soon as the avatar has been set
 //        @Nullable
@@ -422,12 +426,10 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 //        if (accountSwitcherDrawable != null) {
 //            DrawableCompat.setTint(accountSwitcherDrawable, textColor);
 //        }
-
-        binding.listMenuButton.setBackgroundColor(mainColor);
-        binding.listMenuButton.setColorFilter(textColor);
+        DrawableCompat.setTint(headerBinding.logo.getDrawable(), ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
 
         headerBinding.headerView.setBackgroundColor(mainColor);
-        headerBinding.appName.setTextColor(textColor);
+        headerBinding.appName.setTextColor(ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
     }
 
     @Override
@@ -523,8 +525,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                         recreate();
                     }
                     @ColorInt final int mainColor = parseColor(response.getColor());
-                    @ColorInt final int textColor = parseColor(response.getTextColor());
-                    runOnUiThread(() -> Application.saveBrandColors(MainActivity.this, mainColor, textColor));
+                    runOnUiThread(() -> Application.saveBrandColors(MainActivity.this, mainColor));
                 }
             }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -95,7 +95,6 @@ import it.niedermann.nextcloud.deck.ui.stack.EditStackListener;
 import it.niedermann.nextcloud.deck.ui.stack.OnScrollListener;
 import it.niedermann.nextcloud.deck.ui.stack.StackAdapter;
 import it.niedermann.nextcloud.deck.ui.stack.StackFragment;
-import it.niedermann.nextcloud.deck.util.ColorUtil;
 import it.niedermann.nextcloud.deck.util.DrawerMenuUtil;
 
 import static android.graphics.Color.parseColor;
@@ -106,6 +105,7 @@ import static it.niedermann.nextcloud.deck.Application.NO_STACK_ID;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
 import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToFAB;
 import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToPrimaryTabLayout;
+import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ABOUT;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ADD_BOARD;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ARCHIVED_BOARDS;
@@ -419,10 +419,12 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
     public void applyBrand(@ColorInt int mainColor) {
         applyBrandToPrimaryTabLayout(mainColor, binding.stackTitles);
         applyBrandToFAB(mainColor, binding.fab);
+        // TODO We assume, that the background of the spinner is always white
+        binding.swipeRefreshLayout.setColorSchemeColors(contrastRatioIsSufficient(Color.WHITE, mainColor) ? mainColor : colorAccent);
         headerBinding.headerView.setBackgroundColor(mainColor);
-        @ColorInt final int finalTextColor = ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK;
-        DrawableCompat.setTint(headerBinding.logo.getDrawable(), finalTextColor);
-        headerBinding.appName.setTextColor(finalTextColor);
+        @ColorInt final int headerTextColor = contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK;
+        DrawableCompat.setTint(headerBinding.logo.getDrawable(), headerTextColor);
+        headerBinding.appName.setTextColor(headerTextColor);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -416,9 +416,10 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
     public void applyBrand(@ColorInt int mainColor) {
         applyBrandToPrimaryTabLayout(mainColor, binding.stackTitles);
         applyBrandToFAB(mainColor, binding.fab);
-        DrawableCompat.setTint(headerBinding.logo.getDrawable(), ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
         headerBinding.headerView.setBackgroundColor(mainColor);
-        headerBinding.appName.setTextColor(ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
+        @ColorInt final int finalTextColor = ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK;
+        DrawableCompat.setTint(headerBinding.logo.getDrawable(), finalTextColor);
+        headerBinding.appName.setTextColor(finalTextColor);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -415,14 +415,6 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
     public void applyBrand(@ColorInt int mainColor) {
         applyBrandToPrimaryTabLayout(mainColor, binding.stackTitles);
         applyBrandToFAB(mainColor, binding.fab);
-
-
-        // Is null as soon as the avatar has been set
-//        @Nullable
-//        Drawable accountSwitcherDrawable = binding.accountSwitcher.getDrawable();
-//        if (accountSwitcherDrawable != null) {
-//            DrawableCompat.setTint(accountSwitcherDrawable, textColor);
-//        }
         DrawableCompat.setTint(headerBinding.logo.getDrawable(), ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);
         headerBinding.headerView.setBackgroundColor(mainColor);
         headerBinding.appName.setTextColor(ColorUtil.contrastRatioIsSufficient(mainColor, Color.WHITE) ? Color.WHITE : Color.BLACK);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -104,6 +104,7 @@ import static it.niedermann.nextcloud.deck.Application.NO_ACCOUNT_ID;
 import static it.niedermann.nextcloud.deck.Application.NO_BOARD_ID;
 import static it.niedermann.nextcloud.deck.Application.NO_STACK_ID;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToFAB;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ABOUT;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ADD_BOARD;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ARCHIVED_BOARDS;

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -105,6 +105,7 @@ import static it.niedermann.nextcloud.deck.Application.NO_BOARD_ID;
 import static it.niedermann.nextcloud.deck.Application.NO_STACK_ID;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
 import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToFAB;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToPrimaryTabLayout;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ABOUT;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ADD_BOARD;
 import static it.niedermann.nextcloud.deck.util.DrawerMenuUtil.MENU_ID_ARCHIVED_BOARDS;

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -161,6 +161,8 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
 
         Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler(this));
 
+        setTheme(R.style.AppTheme);
+
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         headerBinding = NavHeaderMainBinding.bind(binding.navigationView.getHeaderView(0));
         setContentView(binding.getRoot());

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/PushNotificationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/PushNotificationActivity.java
@@ -24,6 +24,7 @@ import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 
 import static android.graphics.Color.parseColor;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class PushNotificationActivity extends BrandedActivity {
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/PushNotificationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/PushNotificationActivity.java
@@ -9,7 +9,6 @@ import android.view.View;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.nextcloud.android.sso.helper.SingleAccountHelper;
 
@@ -19,17 +18,14 @@ import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ActivityPushNotificationBinding;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
-import it.niedermann.nextcloud.deck.ui.branding.Branded;
+import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 
 import static android.graphics.Color.parseColor;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.applyBrandToPrimaryToolbar;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.applyBrandToStatusbar;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
 
-public class PushNotificationActivity extends AppCompatActivity implements Branded {
+public class PushNotificationActivity extends BrandedActivity {
 
     private ActivityPushNotificationBinding binding;
 
@@ -84,7 +80,7 @@ public class PushNotificationActivity extends AppCompatActivity implements Brand
                         final SyncManager syncManager = new SyncManager(this);
                         try {
                             if (brandingEnabled) {
-                                applyBrand(parseColor(account.getColor()), parseColor(account.getTextColor()));
+                                applyBrand(parseColor(account.getColor()));
                             }
                         } catch (Throwable t) {
                             DeckLog.logError(t);
@@ -154,7 +150,7 @@ public class PushNotificationActivity extends AppCompatActivity implements Brand
     @UiThread
     private void launchEditActivity(@NonNull Account account, Long boardId, Long cardId) {
         try {
-            Application.saveBrandColors(this, Color.parseColor(account.getColor()), Color.parseColor(account.getTextColor()));
+            Application.saveBrandColors(this, Color.parseColor(account.getColor()));
         } catch (Throwable t) {
             DeckLog.logError(t);
         }
@@ -170,10 +166,9 @@ public class PushNotificationActivity extends AppCompatActivity implements Brand
     }
 
     @Override
-    public void applyBrand(@ColorInt int mainColor, @ColorInt int textColor) {
+    public void applyBrand(@ColorInt int mainColor) {
         if (brandingEnabled) {
-            applyBrandToStatusbar(getWindow(), mainColor, textColor);
-            applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
+            applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
             binding.cancel.setTextColor(getSecondaryForegroundColorDependingOnTheme(this, mainColor));
         }
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/PushNotificationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/PushNotificationActivity.java
@@ -168,7 +168,6 @@ public class PushNotificationActivity extends BrandedActivity {
     @Override
     public void applyBrand(@ColorInt int mainColor) {
         if (brandingEnabled) {
-            applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
             binding.cancel.setTextColor(getSecondaryForegroundColorDependingOnTheme(this, mainColor));
         }
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutActivity.java
@@ -19,6 +19,8 @@ import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToPrimaryTabLayout;
+
 public class AboutActivity extends BrandedActivity {
     private static final String BUNDLE_KEY_ACCOUNT = "account";
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutActivity.java
@@ -82,9 +82,9 @@ public class AboutActivity extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
-        applyBrandToPrimaryTabLayout(mainColor, textColor, binding.tabLayout);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        applyBrandToPrimaryTabLayout(mainColor, binding.tabLayout);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutActivity.java
@@ -83,7 +83,6 @@ public class AboutActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
         applyBrandToPrimaryTabLayout(mainColor, binding.tabLayout);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentLicenseTab.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentLicenseTab.java
@@ -29,8 +29,8 @@ public class AboutFragmentLicenseTab extends BrandedFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         binding.aboutAppLicenseButton.setBackgroundColor(mainColor);
-        binding.aboutAppLicenseButton.setTextColor(textColor);
+        binding.aboutAppLicenseButton.setTextColor(mainColor);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentLicenseTab.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentLicenseTab.java
@@ -1,17 +1,22 @@
 package it.niedermann.nextcloud.deck.ui.about;
 
 import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.core.graphics.drawable.DrawableCompat;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.FragmentAboutLicenseTabBinding;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedFragment;
+import it.niedermann.nextcloud.deck.ui.branding.BrandingUtil;
+import it.niedermann.nextcloud.deck.util.ColorUtil;
 
 import static it.niedermann.nextcloud.deck.util.SpannableUtil.setTextWithURL;
 
@@ -30,7 +35,8 @@ public class AboutFragmentLicenseTab extends BrandedFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        binding.aboutAppLicenseButton.setBackgroundColor(mainColor);
-        binding.aboutAppLicenseButton.setTextColor(mainColor);
+        @ColorInt final int finalMainColor = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
+        DrawableCompat.setTintList(binding.aboutAppLicenseButton.getBackground(), ColorStateList.valueOf(finalMainColor));
+        binding.aboutAppLicenseButton.setTextColor(ColorUtil.getForegroundColorForBackgroundColor(finalMainColor));
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentLicenseTab.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentLicenseTab.java
@@ -2,6 +2,7 @@ package it.niedermann.nextcloud.deck.ui.about;
 
 import android.content.Intent;
 import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -10,14 +11,16 @@ import android.view.ViewGroup;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 
+import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.FragmentAboutLicenseTabBinding;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedFragment;
-import it.niedermann.nextcloud.deck.ui.branding.BrandingUtil;
 import it.niedermann.nextcloud.deck.util.ColorUtil;
 
+import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficientBigAreas;
 import static it.niedermann.nextcloud.deck.util.SpannableUtil.setTextWithURL;
 
 public class AboutFragmentLicenseTab extends BrandedFragment {
@@ -35,7 +38,9 @@ public class AboutFragmentLicenseTab extends BrandedFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        @ColorInt final int finalMainColor = BrandingUtil.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
+        @ColorInt final int finalMainColor = contrastRatioIsSufficientBigAreas(mainColor, ContextCompat.getColor(requireContext(), R.color.primary))
+                ? mainColor
+                : Application.isDarkTheme(requireContext()) ? Color.WHITE : Color.BLACK;
         DrawableCompat.setTintList(binding.aboutAppLicenseButton.getBackground(), ColorStateList.valueOf(finalMainColor));
         binding.aboutAppLicenseButton.setTextColor(ColorUtil.getForegroundColorForBackgroundColor(finalMainColor));
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherDialog.java
@@ -53,7 +53,8 @@ public class AccountSwitcherDialog extends BrandedDialogFragment {
 
         Glide.with(requireContext())
                 .load(viewModel.getCurrentAccount().getAvatarUrl(dpToPx(binding.currentAccountItemAvatar.getContext(), R.dimen.avatar_size)))
-                .error(R.drawable.ic_person_grey600_24dp)
+                .placeholder(R.drawable.ic_baseline_account_circle_24)
+                .error(R.drawable.ic_baseline_account_circle_24)
                 .apply(RequestOptions.circleCropTransform())
                 .into(binding.currentAccountItemAvatar);
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherDialog.java
@@ -97,7 +97,7 @@ public class AccountSwitcherDialog extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
 //        applyBrandToLayerDrawable((LayerDrawable) binding.check.getDrawable(), R.id.area, mainColor);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/accountswitcher/AccountSwitcherViewHolder.java
@@ -31,7 +31,8 @@ public class AccountSwitcherViewHolder extends RecyclerView.ViewHolder {
         binding.accountHost.setText(Uri.parse(account.getUrl()).getHost());
         Glide.with(itemView.getContext())
                 .load(new SingleSignOnUrl(account.getName(), account.getAvatarUrl(dpToPx(binding.accountItemAvatar.getContext(), R.dimen.avatar_size))))
-                .error(R.drawable.ic_person_grey600_24dp)
+                .placeholder(R.drawable.ic_baseline_account_circle_24)
+                .error(R.drawable.ic_baseline_account_circle_24)
                 .apply(RequestOptions.circleCropTransform())
                 .into(binding.accountItemAvatar);
         itemView.setOnClickListener((v) -> onAccountClick.accept(account));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedboards/ArchivedBoardsActvitiy.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedboards/ArchivedBoardsActvitiy.java
@@ -67,8 +67,8 @@ public class ArchivedBoardsActvitiy extends BrandedActivity implements DeleteBoa
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedboards/ArchivedBoardsActvitiy.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedboards/ArchivedBoardsActvitiy.java
@@ -68,7 +68,7 @@ public class ArchivedBoardsActvitiy extends BrandedActivity implements DeleteBoa
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        // Nothing to do...
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedcards/ArchivedCardsActvitiy.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedcards/ArchivedCardsActvitiy.java
@@ -66,7 +66,7 @@ public class ArchivedCardsActvitiy extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        // Nothing to do...
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedcards/ArchivedCardsActvitiy.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedcards/ArchivedCardsActvitiy.java
@@ -65,8 +65,8 @@ public class ArchivedCardsActvitiy extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/EditBoardDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/EditBoardDialogFragment.java
@@ -95,7 +95,7 @@ public class EditBoardDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, textColor, binding.input);
+    public void applyBrand(int mainColor) {
+        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/EditBoardDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/EditBoardDialogFragment.java
@@ -15,9 +15,10 @@ import it.niedermann.nextcloud.deck.databinding.DialogTextColorInputBinding;
 import it.niedermann.nextcloud.deck.model.full.FullBoard;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.MainViewModel;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
+
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
 
 public class EditBoardDialogFragment extends BrandedDialogFragment {
 
@@ -96,6 +97,6 @@ public class EditBoardDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
+        applyBrandToEditText(mainColor, binding.input);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlAdapter.java
@@ -25,10 +25,9 @@ import it.niedermann.nextcloud.deck.model.AccessControl;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.enums.DBStatus;
 import it.niedermann.nextcloud.deck.ui.branding.Branded;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.util.ViewUtil;
 
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class AccessControlAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements Branded {
 
@@ -161,7 +160,7 @@ public class AccessControlAdapter extends RecyclerView.Adapter<RecyclerView.View
     @Override
     public void applyBrand(int mainColor) {
         if (Application.isBrandingEnabled(context)) {
-            this.mainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
+            this.mainColor = getSecondaryForegroundColorDependingOnTheme(context, mainColor);
             notifyDataSetChanged();
         }
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlAdapter.java
@@ -159,7 +159,7 @@ public class AccessControlAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         if (Application.isBrandingEnabled(context)) {
             this.mainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
             notifyDataSetChanged();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
@@ -25,7 +25,6 @@ import it.niedermann.nextcloud.deck.model.full.FullBoard;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.WrappedLiveData;
 import it.niedermann.nextcloud.deck.ui.MainViewModel;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedSnackbar;
@@ -34,6 +33,7 @@ import it.niedermann.nextcloud.deck.ui.exception.ExceptionDialogFragment;
 
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
 import static it.niedermann.nextcloud.deck.ui.board.accesscontrol.AccessControlAdapter.HEADER_ITEM_LOCAL_ID;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
 
 public class AccessControlDialogFragment extends BrandedDialogFragment implements AccessControlChangedListener, OnItemClickListener {
 
@@ -136,7 +136,7 @@ public class AccessControlDialogFragment extends BrandedDialogFragment implement
 
     @Override
     public void applyBrand(int mainColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, binding.people);
+        applyBrandToEditText(mainColor, binding.people);
         this.adapter.applyBrand(mainColor);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/accesscontrol/AccessControlDialogFragment.java
@@ -135,9 +135,9 @@ public class AccessControlDialogFragment extends BrandedDialogFragment implement
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, textColor, binding.people);
-        this.adapter.applyBrand(mainColor, textColor);
+    public void applyBrand(int mainColor) {
+        BrandedActivity.applyBrandToEditText(mainColor, binding.people);
+        this.adapter.applyBrand(mainColor);
     }
 
     public static DialogFragment newInstance(long boardLocalId) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/EditLabelDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/EditLabelDialogFragment.java
@@ -11,9 +11,10 @@ import androidx.fragment.app.DialogFragment;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.DialogTextColorInputBinding;
 import it.niedermann.nextcloud.deck.model.Label;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
+
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
 
 public class EditLabelDialogFragment extends BrandedDialogFragment {
 
@@ -84,6 +85,6 @@ public class EditLabelDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
+        applyBrandToEditText(mainColor, binding.input);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/EditLabelDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/EditLabelDialogFragment.java
@@ -83,7 +83,7 @@ public class EditLabelDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, textColor, binding.input);
+    public void applyBrand(int mainColor) {
+        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsAdapter.java
@@ -74,7 +74,7 @@ public class ManageLabelsAdapter extends RecyclerView.Adapter<ManageLabelsViewHo
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         if (Application.isBrandingEnabled(context)) {
             this.mainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
             notifyDataSetChanged();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsAdapter.java
@@ -16,7 +16,8 @@ import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ItemManageLabelBinding;
 import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.ui.branding.Branded;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
+
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class ManageLabelsAdapter extends RecyclerView.Adapter<ManageLabelsViewHolder> implements Branded {
 
@@ -76,7 +77,7 @@ public class ManageLabelsAdapter extends RecyclerView.Adapter<ManageLabelsViewHo
     @Override
     public void applyBrand(int mainColor) {
         if (Application.isBrandingEnabled(context)) {
-            this.mainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
+            this.mainColor = getSecondaryForegroundColorDependingOnTheme(context, mainColor);
             notifyDataSetChanged();
         }
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsDialogFragment.java
@@ -20,12 +20,13 @@ import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.WrappedLiveData;
 import it.niedermann.nextcloud.deck.ui.MainViewModel;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDeleteAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
 
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToFAB;
 
 public class ManageLabelsDialogFragment extends BrandedDialogFragment implements ManageLabelListener, EditLabelListener {
 
@@ -109,8 +110,8 @@ public class ManageLabelsDialogFragment extends BrandedDialogFragment implements
 
     @Override
     public void applyBrand(int mainColor) {
-        BrandedActivity.applyBrandToFAB(mainColor, binding.fab);
-        BrandedActivity.applyBrandToEditText(mainColor, binding.addLabelTitle);
+        applyBrandToFAB(mainColor, binding.fab);
+        applyBrandToEditText(mainColor, binding.addLabelTitle);
     }
 
     public static DialogFragment newInstance(long boardLocalId) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/board/managelabels/ManageLabelsDialogFragment.java
@@ -108,9 +108,9 @@ public class ManageLabelsDialogFragment extends BrandedDialogFragment implements
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        BrandedActivity.applyBrandToFAB(mainColor, textColor, binding.fab);
-        BrandedActivity.applyBrandToEditText(mainColor, textColor, binding.addLabelTitle);
+    public void applyBrand(int mainColor) {
+        BrandedActivity.applyBrandToFAB(mainColor, binding.fab);
+        BrandedActivity.applyBrandToEditText(mainColor, binding.addLabelTitle);
     }
 
     public static DialogFragment newInstance(long boardLocalId) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/Branded.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/Branded.java
@@ -5,5 +5,5 @@ import androidx.annotation.UiThread;
 
 public interface Branded {
     @UiThread
-    void applyBrand(@ColorInt int mainColor, @ColorInt int textColor);
+    void applyBrand(@ColorInt int mainColor);
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -11,6 +11,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -51,6 +52,7 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
 
     protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
         @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(this, mainColor);
+        tabLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.primary));
         tabLayout.setTabTextColors(finalMainColor, finalMainColor);
         tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
         tabLayout.setSelectedTabIndicatorColor(finalMainColor);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -1,20 +1,14 @@
 package it.niedermann.nextcloud.deck.ui.branding;
 
-import android.content.res.ColorStateList;
 import android.util.TypedValue;
 import android.view.Menu;
 
 import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
-
-import com.google.android.material.tabs.TabLayout;
 
 import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.R;
 
-import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.tintMenuIcon;
 
 public abstract class BrandedActivity extends AppCompatActivity implements Branded {
@@ -42,13 +36,5 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
             tintMenuIcon(menu.getItem(i), colorAccent);
         }
         return super.onCreateOptionsMenu(menu);
-    }
-
-    protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
-        @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(this, mainColor);
-        tabLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.primary));
-//        tabLayout.setTabTextColors(finalMainColor, finalMainColor);
-        tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
-        tabLayout.setSelectedTabIndicatorColor(finalMainColor);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -5,14 +5,12 @@ import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.TypedValue;
-import android.view.Menu;
 import android.widget.EditText;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -23,6 +21,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 
 import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
+import static it.niedermann.nextcloud.deck.util.ColorUtil.getForegroundColorForBackgroundColor;
 
 public abstract class BrandedActivity extends AppCompatActivity implements Branded {
 
@@ -50,41 +49,16 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
         }
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-//        for (int i = 0; i < menu.size(); i++) {
-//            Drawable drawable = menu.getItem(i).getIcon();
-//            if (drawable != null) {
-//                drawable = DrawableCompat.wrap(drawable);
-//                DrawableCompat.setTint(drawable, colorAccent);
-//                menu.getItem(i).setIcon(drawable);
-//            }
-//        }
-        return super.onCreateOptionsMenu(menu);
-    }
-
-    public void applyBrandToPrimaryToolbar(@ColorInt int mainColor, @NonNull Toolbar toolbar) {
-//        final Drawable overflowDrawable = toolbar.getOverflowIcon();
-//        if (overflowDrawable != null) {
-//            overflowDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
-//            toolbar.setOverflowIcon(overflowDrawable);
-//        }
-//
-//        final Drawable navigationDrawable = toolbar.getNavigationIcon();
-//        if (navigationDrawable != null) {
-//            navigationDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
-//            toolbar.setNavigationIcon(navigationDrawable);
-//        }
-    }
-
     protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
-        tabLayout.setTabTextColors(mainColor, mainColor);
-        tabLayout.setTabIconTint(ColorStateList.valueOf(mainColor));
-        tabLayout.setSelectedTabIndicatorColor(mainColor);
+        @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(this, mainColor);
+        tabLayout.setTabTextColors(finalMainColor, finalMainColor);
+        tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
+        tabLayout.setSelectedTabIndicatorColor(finalMainColor);
     }
 
     public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {
         fab.setSupportBackgroundTintList(ColorStateList.valueOf(mainColor));
+        fab.setColorFilter(getForegroundColorForBackgroundColor(mainColor));
     }
 
     public static void applyBrandToEditText(@ColorInt int mainColor, @NonNull EditText editText) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -2,6 +2,7 @@ package it.niedermann.nextcloud.deck.ui.branding;
 
 import android.content.res.ColorStateList;
 import android.util.TypedValue;
+import android.view.Menu;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -14,6 +15,7 @@ import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.R;
 
 import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.tintMenuIcon;
 
 public abstract class BrandedActivity extends AppCompatActivity implements Branded {
 
@@ -32,6 +34,14 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
             @ColorInt final int mainColor = Application.readBrandMainColor(this);
             applyBrand(mainColor);
         }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        for (int i = 0; i < menu.size(); i++) {
+            tintMenuIcon(menu.getItem(i), colorAccent);
+        }
+        return super.onCreateOptionsMenu(menu);
     }
 
     protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -1,12 +1,10 @@
 package it.niedermann.nextcloud.deck.ui.branding;
 
 import android.content.res.ColorStateList;
-import android.os.Bundle;
 import android.util.TypedValue;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 
@@ -21,13 +19,6 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
 
     @ColorInt
     protected int colorAccent;
-
-    @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        @ColorInt final int mainColor = Application.readBrandMainColor(this);
-        setTheme(R.style.AppTheme);
-    }
 
     @Override
     protected void onStart() {
@@ -46,7 +37,7 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
     protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
         @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(this, mainColor);
         tabLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.primary));
-        tabLayout.setTabTextColors(finalMainColor, finalMainColor);
+//        tabLayout.setTabTextColors(finalMainColor, finalMainColor);
         tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
         tabLayout.setSelectedTabIndicatorColor(finalMainColor);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -1,28 +1,21 @@
 package it.niedermann.nextcloud.deck.ui.branding;
 
-import android.content.Context;
 import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.util.TypedValue;
-import android.widget.EditText;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
 
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.tabs.TabLayout;
 
 import it.niedermann.nextcloud.deck.Application;
-import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 
-import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
-import static it.niedermann.nextcloud.deck.util.ColorUtil.getForegroundColorForBackgroundColor;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public abstract class BrandedActivity extends AppCompatActivity implements Branded {
 
@@ -56,48 +49,5 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
         tabLayout.setTabTextColors(finalMainColor, finalMainColor);
         tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
         tabLayout.setSelectedTabIndicatorColor(finalMainColor);
-    }
-
-    public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {
-        fab.setSupportBackgroundTintList(ColorStateList.valueOf(mainColor));
-        fab.setColorFilter(getForegroundColorForBackgroundColor(mainColor));
-    }
-
-    public static void applyBrandToEditText(@ColorInt int mainColor, @NonNull EditText editText) {
-        @ColorInt final int finalMainColor = getSecondaryForegroundColorDependingOnTheme(editText.getContext(), mainColor);
-        DrawableCompat.setTintList(editText.getBackground(), new ColorStateList(
-                new int[][]{
-                        new int[]{android.R.attr.state_active},
-                        new int[]{android.R.attr.state_activated},
-                        new int[]{android.R.attr.state_focused},
-                        new int[]{android.R.attr.state_pressed},
-                        new int[]{}
-                },
-                new int[]{
-                        finalMainColor,
-                        finalMainColor,
-                        finalMainColor,
-                        finalMainColor,
-                        editText.getContext().getResources().getColor(R.color.fg_secondary)
-                }
-        ));
-    }
-
-    /**
-     * Since we may collide with dark theme in this area, we have to make sure that the color is visible depending on the background
-     */
-    @ColorInt
-    public static int
-    getSecondaryForegroundColorDependingOnTheme(@NonNull Context context, @ColorInt int mainColor) {
-        final boolean isDarkTheme = Application.getAppTheme(context);
-        if (isDarkTheme && !contrastRatioIsSufficient(mainColor, Color.BLACK)) {
-            DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and dark theme is too low. Falling back to WHITE as brand color.");
-            return Color.WHITE;
-        } else if (!isDarkTheme && !contrastRatioIsSufficient(mainColor, Color.WHITE)) {
-            DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and light theme is too low. Falling back to BLACK as brand color.");
-            return Color.BLACK;
-        } else {
-            return mainColor;
-        }
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -6,9 +6,8 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.Menu;
-import android.view.View;
-import android.view.Window;
 import android.widget.EditText;
 
 import androidx.annotation.ColorInt;
@@ -24,101 +23,73 @@ import com.google.android.material.tabs.TabLayout;
 import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
-import it.niedermann.nextcloud.deck.util.ColorUtil;
 
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static android.os.Build.VERSION_CODES.M;
 import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
-import static it.niedermann.nextcloud.deck.util.ColorUtil.isColorDark;
 
 public abstract class BrandedActivity extends AppCompatActivity implements Branded {
+
+    @ColorInt
+    protected int colorAccent;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if (Application.isBrandingEnabled(this)) {
-            @ColorInt final int mainColor = Application.readBrandMainColor(this);
-            @ColorInt final int textColor = Application.readBrandTextColor(this);
-            setTheme(ColorUtil.isColorDark(textColor) ? R.style.AppThemeLightBrand : R.style.AppTheme);
-            applyBrandToStatusbar(getWindow(), mainColor, textColor);
-        } else {
-            setTheme(R.style.AppTheme);
-        }
+        @ColorInt final int mainColor = Application.readBrandMainColor(this);
+        setTheme(R.style.AppTheme);
     }
 
     @Override
     protected void onStart() {
         super.onStart();
 
+        final TypedValue typedValue = new TypedValue();
+        getTheme().resolveAttribute(R.attr.colorAccent, typedValue, true);
+        colorAccent = typedValue.data;
+
         if (Application.isBrandingEnabled(this)) {
             @ColorInt final int mainColor = Application.readBrandMainColor(this);
-            @ColorInt final int textColor = Application.readBrandTextColor(this);
-            applyBrand(mainColor, textColor);
+            applyBrand(mainColor);
         }
     }
 
-    // TODO maybe this can be handled in R.style.AppThemLightBrand
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        @ColorInt final int textColor = Application.readBrandTextColor(this);
         for (int i = 0; i < menu.size(); i++) {
             Drawable drawable = menu.getItem(i).getIcon();
             if (drawable != null) {
                 drawable = DrawableCompat.wrap(drawable);
-                DrawableCompat.setTint(drawable, textColor);
+                DrawableCompat.setTint(drawable, colorAccent);
                 menu.getItem(i).setIcon(drawable);
             }
         }
         return super.onCreateOptionsMenu(menu);
     }
 
-    public static void applyBrandToStatusbar(@NonNull Window window, @ColorInt int mainColor, @ColorInt int textColor) {
-        if (SDK_INT >= LOLLIPOP) { // Set status bar color
-            window.setStatusBarColor(mainColor);
-            if (SDK_INT >= M) { // Set icon and text color of status bar
-                final View decorView = window.getDecorView();
-                if (isColorDark(mainColor)) {
-                    int flags = decorView.getSystemUiVisibility();
-                    flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-                    decorView.setSystemUiVisibility(flags);
-                } else {
-                    decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-                }
-            }
-        }
-    }
-
-    public static void applyBrandToPrimaryToolbar(@ColorInt int mainColor, @ColorInt int textColor, @NonNull Toolbar toolbar) {
-        toolbar.setBackgroundColor(mainColor);
-        toolbar.setTitleTextColor(textColor);
+    public void applyBrandToPrimaryToolbar(@ColorInt int mainColor, @NonNull Toolbar toolbar) {
         final Drawable overflowDrawable = toolbar.getOverflowIcon();
         if (overflowDrawable != null) {
-            overflowDrawable.setColorFilter(textColor, PorterDuff.Mode.SRC_ATOP);
+            overflowDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
             toolbar.setOverflowIcon(overflowDrawable);
         }
 
         final Drawable navigationDrawable = toolbar.getNavigationIcon();
         if (navigationDrawable != null) {
-            navigationDrawable.setColorFilter(textColor, PorterDuff.Mode.SRC_ATOP);
+            navigationDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
             toolbar.setNavigationIcon(navigationDrawable);
         }
     }
 
-    protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @ColorInt int textColor, @NonNull TabLayout tabLayout) {
-        tabLayout.setBackgroundColor(mainColor);
-        tabLayout.setTabTextColors(textColor, textColor);
-        tabLayout.setTabIconTint(ColorStateList.valueOf(textColor));
-        tabLayout.setSelectedTabIndicatorColor(textColor);
+    protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
+        tabLayout.setTabTextColors(mainColor, mainColor);
+        tabLayout.setTabIconTint(ColorStateList.valueOf(mainColor));
+        tabLayout.setSelectedTabIndicatorColor(mainColor);
     }
 
-    public static void applyBrandToFAB(@ColorInt int mainColor, @ColorInt int textColor, @NonNull FloatingActionButton fab) {
+    public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {
         fab.setSupportBackgroundTintList(ColorStateList.valueOf(mainColor));
-        fab.setColorFilter(textColor);
     }
 
-    public static void applyBrandToEditText(@ColorInt int mainColor, @ColorInt int textColor, @NonNull EditText editText) {
+    public static void applyBrandToEditText(@ColorInt int mainColor, @NonNull EditText editText) {
         @ColorInt final int finalMainColor = getSecondaryForegroundColorDependingOnTheme(editText.getContext(), mainColor);
         DrawableCompat.setTintList(editText.getBackground(), new ColorStateList(
                 new int[][]{

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedActivity.java
@@ -3,8 +3,6 @@ package it.niedermann.nextcloud.deck.ui.branding;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.TypedValue;
 import android.view.Menu;
@@ -54,29 +52,29 @@ public abstract class BrandedActivity extends AppCompatActivity implements Brand
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        for (int i = 0; i < menu.size(); i++) {
-            Drawable drawable = menu.getItem(i).getIcon();
-            if (drawable != null) {
-                drawable = DrawableCompat.wrap(drawable);
-                DrawableCompat.setTint(drawable, colorAccent);
-                menu.getItem(i).setIcon(drawable);
-            }
-        }
+//        for (int i = 0; i < menu.size(); i++) {
+//            Drawable drawable = menu.getItem(i).getIcon();
+//            if (drawable != null) {
+//                drawable = DrawableCompat.wrap(drawable);
+//                DrawableCompat.setTint(drawable, colorAccent);
+//                menu.getItem(i).setIcon(drawable);
+//            }
+//        }
         return super.onCreateOptionsMenu(menu);
     }
 
     public void applyBrandToPrimaryToolbar(@ColorInt int mainColor, @NonNull Toolbar toolbar) {
-        final Drawable overflowDrawable = toolbar.getOverflowIcon();
-        if (overflowDrawable != null) {
-            overflowDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
-            toolbar.setOverflowIcon(overflowDrawable);
-        }
-
-        final Drawable navigationDrawable = toolbar.getNavigationIcon();
-        if (navigationDrawable != null) {
-            navigationDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
-            toolbar.setNavigationIcon(navigationDrawable);
-        }
+//        final Drawable overflowDrawable = toolbar.getOverflowIcon();
+//        if (overflowDrawable != null) {
+//            overflowDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
+//            toolbar.setOverflowIcon(overflowDrawable);
+//        }
+//
+//        final Drawable navigationDrawable = toolbar.getNavigationIcon();
+//        if (navigationDrawable != null) {
+//            navigationDrawable.setColorFilter(colorAccent, PorterDuff.Mode.SRC_ATOP);
+//            toolbar.setNavigationIcon(navigationDrawable);
+//        }
     }
 
     protected void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedAlertDialogBuilder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedAlertDialogBuilder.java
@@ -28,15 +28,14 @@ public class BrandedAlertDialogBuilder extends AlertDialog.Builder implements Br
 
         @NonNull Context context = getContext();
         @ColorInt final int mainColor = Application.readBrandMainColor(context);
-        @ColorInt final int textColor = Application.readBrandTextColor(context);
-        applyBrand(mainColor, textColor);
-        dialog.setOnShowListener(dialog -> applyBrand(mainColor, textColor));
+        applyBrand(mainColor);
+        dialog.setOnShowListener(dialog -> applyBrand(mainColor));
         return dialog;
     }
 
     @CallSuper
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         final Button[] buttons = new Button[3];
         buttons[0] = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
         buttons[1] = dialog.getButton(DialogInterface.BUTTON_NEGATIVE);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedAlertDialogBuilder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedAlertDialogBuilder.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 
 import it.niedermann.nextcloud.deck.Application;
 
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
+
 public class BrandedAlertDialogBuilder extends AlertDialog.Builder implements Branded {
 
     protected AlertDialog dialog;
@@ -42,7 +44,7 @@ public class BrandedAlertDialogBuilder extends AlertDialog.Builder implements Br
         buttons[2] = dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
         for (Button button : buttons) {
             if (button != null) {
-                button.setTextColor(BrandedActivity.getSecondaryForegroundColorDependingOnTheme(button.getContext(), mainColor));
+                button.setTextColor(getSecondaryForegroundColorDependingOnTheme(button.getContext(), mainColor));
             }
         }
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDatePickerDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDatePickerDialog.java
@@ -1,7 +1,6 @@
 package it.niedermann.nextcloud.deck.ui.branding;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,7 +15,6 @@ import com.wdullaer.materialdatetimepicker.date.DatePickerDialog;
 import java.util.Calendar;
 
 import it.niedermann.nextcloud.deck.Application;
-import it.niedermann.nextcloud.deck.util.ColorUtil;
 
 public class BrandedDatePickerDialog extends DatePickerDialog implements Branded {
 
@@ -27,20 +25,19 @@ public class BrandedDatePickerDialog extends DatePickerDialog implements Branded
             setThemeDark(Application.getAppTheme(context));
             if (Application.isBrandingEnabled(context)) {
                 @ColorInt final int mainColor = Application.readBrandMainColor(context);
-                @ColorInt final int textColor = Application.readBrandTextColor(context);
-                applyBrand(mainColor, textColor);
+                applyBrand(mainColor);
             }
         }
         return super.onCreateView(inflater, container, savedInstanceState);
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         @ColorInt final int buttonTextColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
         setOkColor(buttonTextColor);
         setCancelColor(buttonTextColor);
         // Text in picker title is always white
-        setAccentColor(ColorUtil.contrastRatioIsSufficient(Color.WHITE, mainColor) ? mainColor : textColor);
+        setAccentColor(mainColor);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDatePickerDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDatePickerDialog.java
@@ -16,13 +16,15 @@ import java.util.Calendar;
 
 import it.niedermann.nextcloud.deck.Application;
 
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
+
 public class BrandedDatePickerDialog extends DatePickerDialog implements Branded {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         @Nullable Context context = getContext();
         if (context != null) {
-            setThemeDark(Application.getAppTheme(context));
+            setThemeDark(Application.isDarkTheme(context));
             if (Application.isBrandingEnabled(context)) {
                 @ColorInt final int mainColor = Application.readBrandMainColor(context);
                 applyBrand(mainColor);
@@ -33,7 +35,7 @@ public class BrandedDatePickerDialog extends DatePickerDialog implements Branded
 
     @Override
     public void applyBrand(int mainColor) {
-        @ColorInt final int buttonTextColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
+        @ColorInt final int buttonTextColor = getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
         setOkColor(buttonTextColor);
         setCancelColor(buttonTextColor);
         // Text in picker title is always white

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDeleteAlertDialogBuilder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDeleteAlertDialogBuilder.java
@@ -16,8 +16,8 @@ public class BrandedDeleteAlertDialogBuilder extends BrandedAlertDialogBuilder {
 
     @CallSuper
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        super.applyBrand(mainColor, textColor);
+    public void applyBrand(int mainColor) {
+        super.applyBrand(mainColor);
         final Button positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
         if (positiveButton != null) {
             positiveButton.setTextColor(getContext().getResources().getColor(R.color.danger));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDialogFragment.java
@@ -18,8 +18,7 @@ public abstract class BrandedDialogFragment extends DialogFragment implements Br
         if (context != null) {
             if (Application.isBrandingEnabled(context)) {
                 @ColorInt final int mainColor = Application.readBrandMainColor(context);
-                @ColorInt final int textColor = Application.readBrandTextColor(context);
-                applyBrand(mainColor, textColor);
+                applyBrand(mainColor);
             }
         }
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedFragment.java
@@ -17,8 +17,7 @@ public abstract class BrandedFragment extends Fragment implements Branded {
         @Nullable Context context = getContext();
         if (context != null && Application.isBrandingEnabled(context)) {
             @ColorInt final int mainColor = Application.readBrandMainColor(context);
-            @ColorInt final int textColor = Application.readBrandTextColor(context);
-            applyBrand(mainColor, textColor);
+            applyBrand(mainColor);
         }
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedPreferenceCategory.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedPreferenceCategory.java
@@ -13,7 +13,7 @@ import androidx.preference.PreferenceViewHolder;
 import it.niedermann.nextcloud.deck.Application;
 
 import static it.niedermann.nextcloud.deck.Application.readBrandMainColor;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class BrandedPreferenceCategory extends PreferenceCategory {
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedSwitchPreference.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedSwitchPreference.java
@@ -16,17 +16,12 @@ import androidx.preference.SwitchPreference;
 import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.R;
 
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
 
 public class BrandedSwitchPreference extends SwitchPreference implements Branded {
 
     @ColorInt
     private Integer mainColor = null;
-
-    @ColorInt
-    private Integer textColor = null;
 
     @Nullable
     private Switch switchView;
@@ -53,16 +48,15 @@ public class BrandedSwitchPreference extends SwitchPreference implements Branded
 
         if (Application.isBrandingEnabled(getContext()) && holder.itemView instanceof ViewGroup) {
             switchView = findSwitchWidget(holder.itemView);
-            if (mainColor != null && textColor != null) {
+            if (mainColor != null) {
                 applyBrand();
             }
         }
     }
 
     @Override
-    public void applyBrand(@ColorInt int mainColor, @ColorInt int textColor) {
+    public void applyBrand(@ColorInt int mainColor) {
         this.mainColor = mainColor;
-        this.textColor = textColor;
         // onBindViewHolder is called after applyBrand, therefore we have to store the given values and apply them later.
         if (Application.isBrandingEnabled(getContext())) {
             applyBrand();
@@ -70,7 +64,7 @@ public class BrandedSwitchPreference extends SwitchPreference implements Branded
     }
 
     private void applyBrand() {
-        if (switchView != null && SDK_INT >= JELLY_BEAN) {
+        if (switchView != null) {
             final int finalMainColor = getSecondaryForegroundColorDependingOnTheme(getContext(), mainColor);
             // int trackColor = Color.argb(77, Color.red(finalMainColor), Color.green(finalMainColor), Color.blue(finalMainColor));
             DrawableCompat.setTintList(switchView.getThumbDrawable(), new ColorStateList(

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedSwitchPreference.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedSwitchPreference.java
@@ -16,7 +16,7 @@ import androidx.preference.SwitchPreference;
 import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.R;
 
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class BrandedSwitchPreference extends SwitchPreference implements Branded {
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedTimePickerDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedTimePickerDialog.java
@@ -1,7 +1,6 @@
 package it.niedermann.nextcloud.deck.ui.branding;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,7 +15,6 @@ import com.wdullaer.materialdatetimepicker.time.TimePickerDialog;
 import java.util.Calendar;
 
 import it.niedermann.nextcloud.deck.Application;
-import it.niedermann.nextcloud.deck.util.ColorUtil;
 
 public class BrandedTimePickerDialog extends TimePickerDialog implements Branded {
 
@@ -27,20 +25,19 @@ public class BrandedTimePickerDialog extends TimePickerDialog implements Branded
             setThemeDark(Application.getAppTheme(context));
             if (Application.isBrandingEnabled(context)) {
                 @ColorInt final int mainColor = Application.readBrandMainColor(context);
-                @ColorInt final int textColor = Application.readBrandTextColor(context);
-                applyBrand(mainColor, textColor);
+                applyBrand(mainColor);
             }
         }
         return super.onCreateView(inflater, container, savedInstanceState);
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         @ColorInt final int buttonTextColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
         setOkColor(buttonTextColor);
         setCancelColor(buttonTextColor);
         // Text in picker title is always white
-        setAccentColor(ColorUtil.contrastRatioIsSufficient(Color.WHITE, mainColor) ? mainColor : textColor);
+        setAccentColor(mainColor);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedTimePickerDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedTimePickerDialog.java
@@ -16,13 +16,15 @@ import java.util.Calendar;
 
 import it.niedermann.nextcloud.deck.Application;
 
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
+
 public class BrandedTimePickerDialog extends TimePickerDialog implements Branded {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         @Nullable Context context = getContext();
         if (context != null) {
-            setThemeDark(Application.getAppTheme(context));
+            setThemeDark(Application.isDarkTheme(context));
             if (Application.isBrandingEnabled(context)) {
                 @ColorInt final int mainColor = Application.readBrandMainColor(context);
                 applyBrand(mainColor);
@@ -33,7 +35,7 @@ public class BrandedTimePickerDialog extends TimePickerDialog implements Branded
 
     @Override
     public void applyBrand(int mainColor) {
-        @ColorInt final int buttonTextColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
+        @ColorInt final int buttonTextColor = getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
         setOkColor(buttonTextColor);
         setCancelColor(buttonTextColor);
         // Text in picker title is always white

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
@@ -3,6 +3,8 @@ package it.niedermann.nextcloud.deck.ui.branding;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.view.MenuItem;
 import android.widget.EditText;
 
 import androidx.annotation.ColorInt;
@@ -60,5 +62,14 @@ public abstract class BrandingUtil {
                         editText.getContext().getResources().getColor(R.color.fg_secondary)
                 }
         ));
+    }
+
+    public static void tintMenuIcon(@NonNull MenuItem menuItem, @ColorInt int color) {
+        Drawable drawable = menuItem.getIcon();
+        if (drawable != null) {
+            drawable = DrawableCompat.wrap(drawable);
+            DrawableCompat.setTint(drawable, color);
+            menuItem.setIcon(drawable);
+        }
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
@@ -7,6 +7,7 @@ import android.widget.EditText;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -28,18 +29,12 @@ public abstract class BrandingUtil {
      * Since we may collide with dark theme in this area, we have to make sure that the color is visible depending on the background
      */
     @ColorInt
-    public static int
-    getSecondaryForegroundColorDependingOnTheme(@NonNull Context context, @ColorInt int mainColor) {
-        final boolean isDarkTheme = Application.isDarkTheme(context);
-        if (isDarkTheme && !contrastRatioIsSufficient(mainColor, Color.BLACK)) {
-            DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and dark theme is too low. Falling back to WHITE as brand color.");
-            return Color.WHITE;
-        } else if (!contrastRatioIsSufficient(mainColor, Color.WHITE)) {
-            DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and light theme is too low. Falling back to BLACK as brand color.");
-            return Color.BLACK;
-        } else {
+    public static int getSecondaryForegroundColorDependingOnTheme(@NonNull Context context, @ColorInt int mainColor) {
+        if (contrastRatioIsSufficient(mainColor, ContextCompat.getColor(context, R.color.primary))) {
             return mainColor;
         }
+        DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and primary theme background is too low. Falling back to WHITE/BLACK as brand color.");
+        return Application.isDarkTheme(context) ? Color.WHITE : Color.BLACK;
     }
 
     public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
@@ -1,0 +1,69 @@
+package it.niedermann.nextcloud.deck.ui.branding;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.widget.EditText;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.core.graphics.drawable.DrawableCompat;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import it.niedermann.nextcloud.deck.Application;
+import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.R;
+
+import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
+import static it.niedermann.nextcloud.deck.util.ColorUtil.getForegroundColorForBackgroundColor;
+
+public abstract class BrandingUtil {
+
+    private BrandingUtil() {
+        // Util class
+    }
+
+    /**
+     * Since we may collide with dark theme in this area, we have to make sure that the color is visible depending on the background
+     */
+    @ColorInt
+    public static int
+    getSecondaryForegroundColorDependingOnTheme(@NonNull Context context, @ColorInt int mainColor) {
+        final boolean isDarkTheme = Application.isDarkTheme(context);
+        if (isDarkTheme && !contrastRatioIsSufficient(mainColor, Color.BLACK)) {
+            DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and dark theme is too low. Falling back to WHITE as brand color.");
+            return Color.WHITE;
+        } else if (!contrastRatioIsSufficient(mainColor, Color.WHITE)) {
+            DeckLog.verbose("Contrast ratio between brand color " + String.format("#%06X", (0xFFFFFF & mainColor)) + " and light theme is too low. Falling back to BLACK as brand color.");
+            return Color.BLACK;
+        } else {
+            return mainColor;
+        }
+    }
+
+    public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {
+        fab.setSupportBackgroundTintList(ColorStateList.valueOf(mainColor));
+        fab.setColorFilter(getForegroundColorForBackgroundColor(mainColor));
+    }
+
+    public static void applyBrandToEditText(@ColorInt int mainColor, @NonNull EditText editText) {
+        @ColorInt final int finalMainColor = getSecondaryForegroundColorDependingOnTheme(editText.getContext(), mainColor);
+        DrawableCompat.setTintList(editText.getBackground(), new ColorStateList(
+                new int[][]{
+                        new int[]{android.R.attr.state_active},
+                        new int[]{android.R.attr.state_activated},
+                        new int[]{android.R.attr.state_focused},
+                        new int[]{android.R.attr.state_pressed},
+                        new int[]{}
+                },
+                new int[]{
+                        finalMainColor,
+                        finalMainColor,
+                        finalMainColor,
+                        finalMainColor,
+                        editText.getContext().getResources().getColor(R.color.fg_secondary)
+                }
+        ));
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
@@ -53,7 +53,6 @@ public abstract class BrandingUtil {
     public static void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
         @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(tabLayout.getContext(), mainColor);
         tabLayout.setBackgroundColor(ContextCompat.getColor(tabLayout.getContext(), R.color.primary));
-        tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
         final boolean contrastRatioIsSufficient = getContrastRatio(mainColor, ContextCompat.getColor(tabLayout.getContext(), R.color.primary)) > 1.7d;
         tabLayout.setSelectedTabIndicatorColor(contrastRatioIsSufficient ? mainColor : finalMainColor);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
@@ -13,12 +13,14 @@ import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.tabs.TabLayout;
 
 import it.niedermann.nextcloud.deck.Application;
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 
 import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
+import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficientBigAreas;
 import static it.niedermann.nextcloud.deck.util.ColorUtil.getContrastRatio;
 import static it.niedermann.nextcloud.deck.util.ColorUtil.getForegroundColorForBackgroundColor;
 
@@ -41,11 +43,19 @@ public abstract class BrandingUtil {
     }
 
     public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {
-        final boolean contrastRatioIsSufficient = getContrastRatio(mainColor, ContextCompat.getColor(fab.getContext(), R.color.primary)) > 1.47d;
+        final boolean contrastRatioIsSufficient = contrastRatioIsSufficientBigAreas(mainColor, ContextCompat.getColor(fab.getContext(), R.color.primary));
         fab.setSupportBackgroundTintList(ColorStateList.valueOf(contrastRatioIsSufficient
                 ? mainColor
                 : ContextCompat.getColor(fab.getContext(), R.color.accent)));
         fab.setColorFilter(contrastRatioIsSufficient ? getForegroundColorForBackgroundColor(mainColor) : mainColor);
+    }
+
+    public static void applyBrandToPrimaryTabLayout(@ColorInt int mainColor, @NonNull TabLayout tabLayout) {
+        @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(tabLayout.getContext(), mainColor);
+        tabLayout.setBackgroundColor(ContextCompat.getColor(tabLayout.getContext(), R.color.primary));
+        tabLayout.setTabIconTint(ColorStateList.valueOf(finalMainColor));
+        final boolean contrastRatioIsSufficient = getContrastRatio(mainColor, ContextCompat.getColor(tabLayout.getContext(), R.color.primary)) > 1.7d;
+        tabLayout.setSelectedTabIndicatorColor(contrastRatioIsSufficient ? mainColor : finalMainColor);
     }
 
     public static void applyBrandToEditText(@ColorInt int mainColor, @NonNull EditText editText) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandingUtil.java
@@ -19,6 +19,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 
 import static it.niedermann.nextcloud.deck.util.ColorUtil.contrastRatioIsSufficient;
+import static it.niedermann.nextcloud.deck.util.ColorUtil.getContrastRatio;
 import static it.niedermann.nextcloud.deck.util.ColorUtil.getForegroundColorForBackgroundColor;
 
 public abstract class BrandingUtil {
@@ -40,8 +41,11 @@ public abstract class BrandingUtil {
     }
 
     public static void applyBrandToFAB(@ColorInt int mainColor, @NonNull FloatingActionButton fab) {
-        fab.setSupportBackgroundTintList(ColorStateList.valueOf(mainColor));
-        fab.setColorFilter(getForegroundColorForBackgroundColor(mainColor));
+        final boolean contrastRatioIsSufficient = getContrastRatio(mainColor, ContextCompat.getColor(fab.getContext(), R.color.primary)) > 1.47d;
+        fab.setSupportBackgroundTintList(ColorStateList.valueOf(contrastRatioIsSufficient
+                ? mainColor
+                : ContextCompat.getColor(fab.getContext(), R.color.accent)));
+        fab.setColorFilter(contrastRatioIsSufficient ? getForegroundColorForBackgroundColor(mainColor) : mainColor);
     }
 
     public static void applyBrandToEditText(@ColorInt int mainColor, @NonNull EditText editText) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
@@ -44,13 +44,13 @@ import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper;
 import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.WrappedLiveData;
 import it.niedermann.nextcloud.deck.ui.branding.Branded;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionDialogFragment;
 import it.niedermann.nextcloud.deck.util.DateUtil;
 import it.niedermann.nextcloud.deck.util.ViewUtil;
 
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 import static it.niedermann.nextcloud.deck.util.MimeTypeUtil.TEXT_PLAIN;
 
 public class CardAdapter extends RecyclerView.Adapter<ItemCardViewHolder> implements DragAndDropAdapter<FullCard>, Branded {
@@ -347,7 +347,7 @@ public class CardAdapter extends RecyclerView.Adapter<ItemCardViewHolder> implem
 
     @Override
     public void applyBrand(int mainColor) {
-        this.mainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
+        this.mainColor = getSecondaryForegroundColorDependingOnTheme(context, mainColor);
         notifyDataSetChanged();
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
@@ -346,7 +346,7 @@ public class CardAdapter extends RecyclerView.Adapter<ItemCardViewHolder> implem
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         this.mainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(context, mainColor);
         notifyDataSetChanged();
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -2,6 +2,7 @@ package it.niedermann.nextcloud.deck.ui.card;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.InputFilter;
@@ -14,11 +15,14 @@ import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
+import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ActivityEditBinding;
 import it.niedermann.nextcloud.deck.model.Account;
@@ -290,6 +294,12 @@ public class EditActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
+        final Drawable navigationIcon = binding.toolbar.getNavigationIcon();
+        if (navigationIcon == null) {
+            DeckLog.error("Excpected navigationIcon to be present.");
+        } else {
+            DrawableCompat.setTint(binding.toolbar.getNavigationIcon(), ContextCompat.getColor(this, R.color.accent));
+        }
         applyBrandToPrimaryTabLayout(mainColor, binding.tabLayout);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -34,6 +34,7 @@ import it.niedermann.nextcloud.deck.util.CardUtil;
 
 import static android.graphics.Color.parseColor;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToPrimaryTabLayout;
 
 public class EditActivity extends BrandedActivity {
     private static final String BUNDLE_KEY_ACCOUNT = "account";

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -290,7 +290,6 @@ public class EditActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
         applyBrandToPrimaryTabLayout(mainColor, binding.tabLayout);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -15,7 +15,6 @@ import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -299,7 +298,7 @@ public class EditActivity extends BrandedActivity {
         if (navigationIcon == null) {
             DeckLog.error("Excpected navigationIcon to be present.");
         } else {
-            DrawableCompat.setTint(binding.toolbar.getNavigationIcon(), ContextCompat.getColor(this, R.color.accent));
+            DrawableCompat.setTint(binding.toolbar.getNavigationIcon(), colorAccent);
         }
         applyBrandToPrimaryTabLayout(mainColor, binding.tabLayout);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -2,7 +2,6 @@ package it.niedermann.nextcloud.deck.ui.card;
 
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.InputFilter;
@@ -89,7 +88,7 @@ public class EditActivity extends BrandedActivity {
         super.onNewIntent(intent);
         setIntent(intent);
         loadDataFromIntent();
-        applyBrand(parseColor(viewModel.getAccount().getColor()), parseColor(viewModel.getAccount().getTextColor()));
+        applyBrand(parseColor(viewModel.getAccount().getColor()));
     }
 
     private void loadDataFromIntent() {
@@ -290,12 +289,9 @@ public class EditActivity extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
-        applyBrandToPrimaryTabLayout(mainColor, textColor, binding.tabLayout);
-        final int highlightColor = Color.argb(77, Color.red(textColor), Color.green(textColor), Color.blue(textColor));
-        binding.title.setHighlightColor(highlightColor);
-        binding.title.setTextColor(textColor);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        applyBrandToPrimaryTabLayout(mainColor, binding.tabLayout);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentAdapter.java
@@ -35,8 +35,6 @@ import it.niedermann.nextcloud.deck.util.DateUtil;
 import it.niedermann.nextcloud.deck.util.MimeTypeUtil;
 
 import static androidx.recyclerview.widget.RecyclerView.NO_ID;
-import static it.niedermann.nextcloud.deck.Application.readBrandMainColor;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
 import static it.niedermann.nextcloud.deck.util.ClipboardUtil.copyToClipboard;
 
 @SuppressWarnings("WeakerAccess")
@@ -73,7 +71,6 @@ public class CardAttachmentAdapter extends RecyclerView.Adapter<AttachmentViewHo
         this.attachmentClickedListener = attachmentClickedListener;
         this.account = account;
         this.cardLocalId = cardLocalId == null ? NO_ID : cardLocalId;
-        this.mainColor = getSecondaryForegroundColorDependingOnTheme(context, readBrandMainColor(context));
         setHasStableIds(true);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
@@ -44,7 +44,7 @@ import it.niedermann.nextcloud.deck.ui.card.EditCardViewModel;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionDialogFragment;
 
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.applyBrandToFAB;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToFAB;
 import static it.niedermann.nextcloud.deck.ui.card.attachments.CardAttachmentAdapter.VIEW_TYPE_DEFAULT;
 import static it.niedermann.nextcloud.deck.ui.card.attachments.CardAttachmentAdapter.VIEW_TYPE_IMAGE;
 import static it.niedermann.nextcloud.deck.util.AttachmentUtil.copyContentUriToTempFile;

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
@@ -275,7 +275,7 @@ public class CardAttachmentsFragment extends BrandedFragment implements Attachme
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToFAB(mainColor, textColor, binding.fab);
+    public void applyBrand(int mainColor) {
+        applyBrandToFAB(mainColor, binding.fab);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsAdapter.java
@@ -17,7 +17,7 @@ import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.ocs.comment.full.FullDeckComment;
 
 import static it.niedermann.nextcloud.deck.Application.readBrandMainColor;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class CardCommentsAdapter extends RecyclerView.Adapter<ItemCommentViewHolder> {
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsEditDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsEditDialogFragment.java
@@ -16,9 +16,10 @@ import java.util.Objects;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.DialogAddCommentBinding;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
+
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
 
 public class CardCommentsEditDialogFragment extends BrandedDialogFragment {
     private static final String BUNDLE_KEY_COMMENT_ID = "commentId";
@@ -79,7 +80,7 @@ public class CardCommentsEditDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
+        applyBrandToEditText(mainColor, binding.input);
     }
 }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsEditDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsEditDialogFragment.java
@@ -78,8 +78,8 @@ public class CardCommentsEditDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, textColor, binding.input);
+    public void applyBrand(int mainColor) {
+        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
     }
 }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsFragment.java
@@ -29,8 +29,8 @@ import it.niedermann.nextcloud.deck.ui.card.EditCardViewModel;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.applyBrandToEditText;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.applyBrandToFAB;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToFAB;
 import static it.niedermann.nextcloud.deck.util.ViewUtil.setupMentions;
 
 public class CardCommentsFragment extends BrandedFragment implements CommentEditedListener, CommentDeletedListener, CommentSelectAsReplyListener {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/comments/CardCommentsFragment.java
@@ -142,9 +142,9 @@ public class CardCommentsFragment extends BrandedFragment implements CommentEdit
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToEditText(mainColor, textColor, binding.message);
-        applyBrandToFAB(mainColor, textColor, binding.fab);
+    public void applyBrand(int mainColor) {
+        applyBrandToEditText(mainColor, binding.message);
+        applyBrandToFAB(mainColor, binding.fab);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
@@ -58,7 +58,7 @@ import it.niedermann.nextcloud.deck.util.ViewUtil;
 
 import static android.text.format.DateFormat.getDateFormat;
 import static it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util.LiveDataHelper.observeOnce;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.applyBrandToEditText;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
 import static it.niedermann.nextcloud.deck.util.DimensionUtil.dpToPx;
 
 public class CardDetailsFragment extends BrandedFragment implements OnDateSetListener, OnTimeSetListener {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
@@ -136,12 +136,12 @@ public class CardDetailsFragment extends BrandedFragment implements OnDateSetLis
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToEditText(mainColor, textColor, binding.labels);
-        applyBrandToEditText(mainColor, textColor, binding.dueDateDate);
-        applyBrandToEditText(mainColor, textColor, binding.dueDateTime);
-        applyBrandToEditText(mainColor, textColor, binding.people);
-        applyBrandToEditText(mainColor, textColor, binding.description);
+    public void applyBrand(int mainColor) {
+        applyBrandToEditText(mainColor, binding.labels);
+        applyBrandToEditText(mainColor, binding.dueDateDate);
+        applyBrandToEditText(mainColor, binding.dueDateTime);
+        applyBrandToEditText(mainColor, binding.people);
+        applyBrandToEditText(mainColor, binding.description);
     }
 
     private void setupDescription() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/filter/FilterDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/filter/FilterDialogFragment.java
@@ -101,7 +101,7 @@ public class FilterDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         @ColorInt int finalMainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
         binding.tabLayout.setSelectedTabIndicatorColor(finalMainColor);
         indicator.setColorFilter(finalMainColor, PorterDuff.Mode.SRC_ATOP);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/filter/FilterDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/filter/FilterDialogFragment.java
@@ -23,9 +23,10 @@ import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.DialogFilterBinding;
 import it.niedermann.nextcloud.deck.model.enums.EDueType;
 import it.niedermann.nextcloud.deck.model.internal.FilterInformation;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
+
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class FilterDialogFragment extends BrandedDialogFragment {
 
@@ -102,7 +103,7 @@ public class FilterDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        @ColorInt int finalMainColor = BrandedActivity.getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
+        @ColorInt int finalMainColor = getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor);
         binding.tabLayout.setSelectedTabIndicatorColor(finalMainColor);
         indicator.setColorFilter(finalMainColor, PorterDuff.Mode.SRC_ATOP);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountViewHolder.java
@@ -34,7 +34,8 @@ public class ManageAccountViewHolder extends RecyclerView.ViewHolder {
         binding.accountHost.setText(Uri.parse(account.getUrl()).getHost());
         Glide.with(itemView.getContext())
                 .load(new SingleSignOnUrl(account.getName(), account.getAvatarUrl(dpToPx(binding.accountItemAvatar.getContext(), R.dimen.avatar_size))))
-                .error(R.drawable.ic_person_grey600_24dp)
+                .placeholder(R.drawable.ic_baseline_account_circle_24)
+                .error(R.drawable.ic_baseline_account_circle_24)
                 .apply(RequestOptions.circleCropTransform())
                 .into(binding.accountItemAvatar);
         binding.currentAccountIndicator.setSelected(isCurrentAccount);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountsActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountsActivity.java
@@ -39,7 +39,7 @@ public class ManageAccountsActivity extends BrandedActivity {
         adapter = new ManageAccountAdapter((account) -> {
             SingleAccountHelper.setCurrentAccount(getApplicationContext(), account.getName());
             syncManager = new SyncManager(this);
-            Application.saveBrandColors(this, Color.parseColor(account.getColor()), Color.parseColor(account.getTextColor()));
+            Application.saveBrandColors(this, Color.parseColor(account.getColor()));
             Application.saveCurrentAccountId(this, account.getId());
         }, (accountPair) -> {
             if (accountPair.first != null) {
@@ -50,7 +50,7 @@ public class ManageAccountsActivity extends BrandedActivity {
             Account newAccount = accountPair.second;
             if (newAccount != null) {
                 SingleAccountHelper.setCurrentAccount(getApplicationContext(), newAccount.getName());
-                Application.saveBrandColors(this, Color.parseColor(newAccount.getColor()), Color.parseColor(newAccount.getTextColor()));
+                Application.saveBrandColors(this, Color.parseColor(newAccount.getColor()));
                 Application.saveCurrentAccountId(this, newAccount.getId());
                 syncManager = new SyncManager(this);
             } else {
@@ -79,7 +79,7 @@ public class ManageAccountsActivity extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountsActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/manageaccounts/ManageAccountsActivity.java
@@ -80,6 +80,6 @@ public class ManageAccountsActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        // Nothing to do...
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/preparecreate/PrepareCreateActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/preparecreate/PrepareCreateActivity.java
@@ -28,6 +28,7 @@ import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 
 import static android.graphics.Color.parseColor;
 import static androidx.lifecycle.Transformations.switchMap;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 
 public class PrepareCreateActivity extends BrandedActivity {
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/preparecreate/PrepareCreateActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/preparecreate/PrepareCreateActivity.java
@@ -225,7 +225,6 @@ public class PrepareCreateActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
         binding.submit.setBackgroundColor(mainColor);
         binding.submit.setTextColor(mainColor);
         binding.cancel.setTextColor(getSecondaryForegroundColorDependingOnTheme(this, mainColor));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/preparecreate/PrepareCreateActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/preparecreate/PrepareCreateActivity.java
@@ -184,7 +184,7 @@ public class PrepareCreateActivity extends BrandedActivity {
             Application.saveCurrentAccountId(this, account.getId());
             Application.saveCurrentBoardId(this, account.getId(), boardId);
             Application.saveCurrentStackId(this, account.getId(), boardId, stackId);
-            applyBrand(parseColor(account.getColor()), parseColor(account.getTextColor()));
+            applyBrand(parseColor(account.getColor()));
 
             finish();
         } else {
@@ -216,7 +216,7 @@ public class PrepareCreateActivity extends BrandedActivity {
     private void applyTemporaryBrand(@Nullable Account account) {
         try {
             if (account != null && brandingEnabled) {
-                applyBrand(parseColor(account.getColor()), parseColor(account.getTextColor()));
+                applyBrand(parseColor(account.getColor()));
             }
         } catch (Throwable t) {
             DeckLog.logError(t);
@@ -224,10 +224,10 @@ public class PrepareCreateActivity extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
         binding.submit.setBackgroundColor(mainColor);
-        binding.submit.setTextColor(textColor);
+        binding.submit.setTextColor(mainColor);
         binding.cancel.setTextColor(getSecondaryForegroundColorDependingOnTheme(this, mainColor));
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsActivity.java
@@ -37,7 +37,7 @@ public class SettingsActivity extends BrandedActivity {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        applyBrandToPrimaryToolbar(mainColor, textColor, binding.toolbar);
+    public void applyBrand(int mainColor) {
+        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsActivity.java
@@ -38,6 +38,6 @@ public class SettingsActivity extends BrandedActivity {
 
     @Override
     public void applyBrand(int mainColor) {
-        applyBrandToPrimaryToolbar(mainColor, binding.toolbar);
+        // Nothing to do...
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
@@ -83,15 +83,14 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Brande
         @Nullable Context context = getContext();
         if (context != null) {
             @ColorInt final int mainColor = Application.readBrandMainColor(context);
-            @ColorInt final int textColor = Application.readBrandTextColor(context);
-            applyBrand(mainColor, textColor);
+            applyBrand(mainColor);
         }
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        wifiOnlyPref.applyBrand(mainColor, textColor);
-        themePref.applyBrand(mainColor, textColor);
-        brandingPref.applyBrand(mainColor, textColor);
+    public void applyBrand(int mainColor) {
+        wifiOnlyPref.applyBrand(mainColor);
+        themePref.applyBrand(mainColor);
+        brandingPref.applyBrand(mainColor);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
@@ -21,7 +21,7 @@ import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionDialogFragment;
 
 import static android.graphics.PorterDuff.Mode;
-import static it.niedermann.nextcloud.deck.ui.branding.BrandedActivity.getSecondaryForegroundColorDependingOnTheme;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.getSecondaryForegroundColorDependingOnTheme;
 import static it.niedermann.nextcloud.deck.util.ExceptionUtil.getDebugInfos;
 
 public class ShareProgressDialogFragment extends BrandedDialogFragment {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareProgressDialogFragment.java
@@ -114,7 +114,7 @@ public class ShareProgressDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         binding.progress.getProgressDrawable().setColorFilter(
                 getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor), Mode.SRC_IN);
         binding.errorReportButton.setTextColor(getSecondaryForegroundColorDependingOnTheme(requireContext(), mainColor));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/stack/EditStackDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/stack/EditStackDialogFragment.java
@@ -90,7 +90,7 @@ public class EditStackDialogFragment extends BrandedDialogFragment {
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, textColor, binding.input);
+    public void applyBrand(int mainColor) {
+        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/stack/EditStackDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/stack/EditStackDialogFragment.java
@@ -17,11 +17,11 @@ import java.util.Objects;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.DialogStackCreateBinding;
-import it.niedermann.nextcloud.deck.ui.branding.BrandedActivity;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedAlertDialogBuilder;
 import it.niedermann.nextcloud.deck.ui.branding.BrandedDialogFragment;
 
 import static it.niedermann.nextcloud.deck.Application.NO_STACK_ID;
+import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.applyBrandToEditText;
 
 public class EditStackDialogFragment extends BrandedDialogFragment {
     private static final String KEY_STACK_ID = "stack_id";
@@ -91,6 +91,6 @@ public class EditStackDialogFragment extends BrandedDialogFragment {
 
     @Override
     public void applyBrand(int mainColor) {
-        BrandedActivity.applyBrandToEditText(mainColor, binding.input);
+        applyBrandToEditText(mainColor, binding.input);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/stack/StackFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/stack/StackFragment.java
@@ -138,9 +138,9 @@ public class StackFragment extends BrandedFragment implements DragAndDropTab<Car
     }
 
     @Override
-    public void applyBrand(int mainColor, int textColor) {
+    public void applyBrand(int mainColor) {
         if (this.adapter != null) {
-            this.adapter.applyBrand(mainColor, textColor);
+            this.adapter.applyBrand(mainColor);
         }
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/OverlappingAvatars.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/view/OverlappingAvatars.java
@@ -48,7 +48,7 @@ public class OverlappingAvatars extends RelativeLayout {
         avatarSize = dpToPx(context, R.dimen.avatar_size_small) + avatarBorderSize * 2;
         overlapPx = dpToPx(context, R.dimen.avatar_size_small_overlapping);
         borderDrawable = getResources().getDrawable(R.drawable.avatar_border);
-        DrawableCompat.setTint(borderDrawable, getResources().getColor(R.color.avatars_overlapping_border_color));
+        DrawableCompat.setTint(borderDrawable, getResources().getColor(R.color.bg_card));
     }
 
     public void setAvatars(@NonNull Account account, @NonNull List<User> assignedUsers) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/ColorUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/ColorUtil.java
@@ -109,7 +109,7 @@ public final class ColorUtil {
         return ret;
     }
 
-    private static double getContrastRatio(@ColorInt int colorOne, @ColorInt int colorTwo) {
+    public static double getContrastRatio(@ColorInt int colorOne, @ColorInt int colorTwo) {
         final double lum1 = getLuminanace(colorOne);
         final double lum2 = getLuminanace(colorTwo);
         final double brightest = Math.max(lum1, lum2);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/ColorUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/ColorUtil.java
@@ -109,6 +109,17 @@ public final class ColorUtil {
         return ret;
     }
 
+    public static boolean contrastRatioIsSufficientBigAreas(@ColorInt int colorOne, @ColorInt int colorTwo) {
+        ColorPair key = new ColorPair(colorOne, colorTwo);
+        Boolean ret = CONTRAST_RATIO_SUFFICIENT_CACHE.get(key);
+        if (ret == null) {
+            ret = getContrastRatio(colorOne, colorTwo) > 1.47d;
+            CONTRAST_RATIO_SUFFICIENT_CACHE.put(key, ret);
+            return ret;
+        }
+        return ret;
+    }
+
     public static double getContrastRatio(@ColorInt int colorOne, @ColorInt int colorTwo) {
         final double lum1 = getLuminanace(colorOne);
         final double lum2 = getLuminanace(colorTwo);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/ViewUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/ViewUtil.java
@@ -53,7 +53,7 @@ public final class ViewUtil {
         long diff = DateUtil.getDayDifference(new Date(), dueDate);
 
         int backgroundDrawable = 0;
-        int textColor = Application.getAppTheme(context) ? R.color.dark_fg_primary : R.color.grey600;
+        int textColor = Application.isDarkTheme(context) ? R.color.dark_fg_primary : R.color.grey600;
 
         if (diff == 1) {
             // due date: tomorrow

--- a/app/src/main/res/drawable/ic_arrow_back_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_white_24dp.xml
@@ -1,5 +1,5 @@
 <vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#FFFFFF" android:viewportHeight="24.0"
+    android:tint="@color/accent" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    <path android:fillColor="@color/accent" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_baseline_account_circle_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_account_circle_24.xml
@@ -1,5 +1,5 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#FFFFFF" android:viewportHeight="24"
+<vector android:height="24dp"
+    android:tint="@color/accent" android:viewportHeight="24"
     android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,5c1.66,0 3,1.34 3,3s-1.34,3 -3,3 -3,-1.34 -3,-3 1.34,-3 3,-3zM12,19.2c-2.5,0 -4.71,-1.28 -6,-3.22 0.03,-1.99 4,-3.08 6,-3.08 1.99,0 5.97,1.09 6,3.08 -1.29,1.94 -3.5,3.22 -6,3.22z"/>
+    <path android:fillColor="@color/accent" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,5c1.66,0 3,1.34 3,3s-1.34,3 -3,3 -3,-1.34 -3,-3 1.34,-3 3,-3zM12,19.2c-2.5,0 -4.71,-1.28 -6,-3.22 0.03,-1.99 4,-3.08 6,-3.08 1.99,0 5.97,1.09 6,3.08 -1.29,1.94 -3.5,3.22 -6,3.22z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_check_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_check_white_24dp.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp"
-    android:tint="@color/accent" android:viewportHeight="24.0"
+    android:tint="@android:color/white" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_check_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_check_white_24dp.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp"
-    android:tint="#FFFFFF" android:viewportHeight="24.0"
+    android:tint="@color/accent" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_close_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_close_white_24dp.xml
@@ -1,5 +1,5 @@
 <vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#FFFFFF" android:viewportHeight="24.0"
+    android:tint="@color/accent" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
 </vector>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout
@@ -21,8 +21,9 @@
             android:id="@+id/tab_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark"
-            app:tabIndicatorColor="@color/accent" />
+            app:tabIndicatorColor="@color/defaultBrand"
+            app:tabMode="fixed"
+            app:tabTextColor="@color/accent" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -21,9 +21,10 @@
             android:id="@+id/tab_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:tabBackground="?attr/colorPrimary"
             app:tabIndicatorColor="@color/defaultBrand"
             app:tabMode="fixed"
-            app:tabTextColor="@color/accent" />
+            app:tabTextColor="?attr/colorAccent" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -15,7 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="?android:actionBarSize"
             app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
-            app:titleTextColor="@android:color/white"
             tools:title="@string/about" />
 
         <com.google.android.material.tabs.TabLayout

--- a/app/src/main/res/layout/activity_archived.xml
+++ b/app/src/main/res/layout/activity_archived.xml
@@ -15,7 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="?android:actionBarSize"
             app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
-            app:titleTextColor="@android:color/white"
             tools:title="@string/archived_cards" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/activity_attachments.xml
+++ b/app/src/main/res/layout/activity_attachments.xml
@@ -16,7 +16,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
-            app:titleTextColor="@android:color/white"
             tools:title="@string/attachments" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -20,7 +20,6 @@
                     android:id="@+id/title"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:theme="@style/EditTextOnPrimaryBackground"
                     android:layout_marginEnd="16dp"
                     android:importantForAutofill="no"
                     android:inputType="textMultiLine"

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -16,15 +16,15 @@
             android:layout_height="wrap_content"
             app:navigationIcon="@drawable/ic_close_white_24dp">
 
-                <EditText
-                    android:id="@+id/title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="16dp"
-                    android:importantForAutofill="no"
-                    android:inputType="textMultiLine"
-                    android:maxLines="5"
-                    tools:text="@tools:sample/lorem" />
+            <EditText
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:importantForAutofill="no"
+                android:inputType="textMultiLine"
+                android:maxLines="5"
+                tools:text="@tools:sample/lorem" />
 
         </androidx.appcompat.widget.Toolbar>
 
@@ -34,9 +34,10 @@
             android:layout_height="wrap_content"
             android:theme="@style/ThemeOverlay.AppCompat.Dark"
             app:tabGravity="center"
-            app:tabIconTint="@android:color/white"
-            app:tabIndicatorColor="@color/accent"
-            app:tabMode="fixed" />
+            app:tabIconTint="?attr/colorAccent"
+            app:tabIndicatorColor="@color/defaultBrand"
+            app:tabMode="fixed"
+            app:tabTextColor="@color/accent" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -33,11 +33,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/ThemeOverlay.AppCompat.Dark"
+            app:tabBackground="?attr/colorPrimary"
             app:tabGravity="center"
             app:tabIconTint="?attr/colorAccent"
             app:tabIndicatorColor="@color/defaultBrand"
             app:tabMode="fixed"
-            app:tabTextColor="@color/accent" />
+            app:tabTextColor="?attr/colorAccent" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/activity_exception.xml
+++ b/app/src/main/res/layout/activity_exception.xml
@@ -14,7 +14,6 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?android:actionBarSize"
-            app:titleTextColor="@android:color/white"
             tools:title="@string/simple_exception" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_import_account.xml
+++ b/app/src/main/res/layout/activity_import_account.xml
@@ -44,6 +44,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/welcome_text"
             android:layout_centerHorizontal="true"
+            android:backgroundTint="@color/defaultBrand"
             android:paddingStart="32dp"
             android:paddingTop="24dp"
             android:paddingEnd="32dp"
@@ -81,6 +82,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="16dp"
             android:text="@string/simple_update"
+            android:textColor="@color/defaultBrand"
             android:visibility="gone"
             tools:visibility="visible" />
     </RelativeLayout>

--- a/app/src/main/res/layout/activity_import_account.xml
+++ b/app/src/main/res/layout/activity_import_account.xml
@@ -44,12 +44,12 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/welcome_text"
             android:layout_centerHorizontal="true"
-            android:backgroundTint="@color/defaultBrand"
             android:paddingStart="32dp"
             android:paddingTop="24dp"
             android:paddingEnd="32dp"
             android:paddingBottom="24dp"
-            android:text="@string/choose_account" />
+            android:text="@string/choose_account"
+            app:backgroundTint="@color/defaultBrand" />
 
         <TextView
             android:id="@+id/status"

--- a/app/src/main/res/layout/activity_import_account.xml
+++ b/app/src/main/res/layout/activity_import_account.xml
@@ -71,6 +71,7 @@
             android:layout_below="@id/add_button"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="32dp"
+            android:indeterminateTint="@color/defaultBrand"
             android:visibility="gone" />
 
         <Button

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -163,9 +163,9 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     app:tabGravity="center"
-                    app:tabIndicatorColor="@color/accent"
+                    app:tabIndicatorColor="@color/defaultBrand"
                     app:tabMode="fixed"
-                    app:tabTextColor="@android:color/white" />
+                    app:tabTextColor="@color/accent" />
 
                 <androidx.appcompat.widget.AppCompatImageButton
                     android:id="@+id/list_menu_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -171,10 +171,10 @@
                     android:id="@+id/list_menu_button"
                     android:layout_width="48dp"
                     android:layout_height="match_parent"
-                    android:background="@android:color/transparent"
+                    android:background="?attr/colorPrimary"
                     android:contentDescription="@string/add_list"
                     android:foreground="?attr/selectableItemBackgroundBorderless"
-                    android:tint="@android:color/white"
+                    android:tint="?attr/colorAccent"
                     android:tooltipText="@string/manage_list"
                     app:srcCompat="@drawable/ic_menu"
                     tools:ignore="UnusedAttribute" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -189,7 +189,7 @@
             android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/fab_margin"
             android:contentDescription="@string/add_card"
-            app:backgroundTint="@color/primary"
+            app:backgroundTint="@color/defaultBrand"
             app:srcCompat="@drawable/ic_add_white_24dp" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -162,10 +162,11 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
+                    app:tabBackground="?attr/colorPrimary"
                     app:tabGravity="center"
                     app:tabIndicatorColor="@color/defaultBrand"
                     app:tabMode="fixed"
-                    app:tabTextColor="@color/accent" />
+                    app:tabTextColor="?attr/colorAccent" />
 
                 <androidx.appcompat.widget.AppCompatImageButton
                     android:id="@+id/list_menu_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -107,9 +107,6 @@
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                android:background="?attr/colorPrimary"
-                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-                app:titleTextColor="@android:color/white"
                 tools:title="Deck">
 
                 <ImageView
@@ -132,6 +129,7 @@
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@string/simple_filter"
                     android:padding="12dp"
+                    android:tint="@color/accent"
                     android:tooltipText="@string/simple_filter"
                     android:translationX="6dp"
                     app:srcCompat="@drawable/ic_filter_list_white_24dp"
@@ -145,6 +143,7 @@
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@string/action_archived_cards"
                     android:padding="12dp"
+                    android:tint="@color/accent"
                     android:tooltipText="@string/action_archived_cards"
                     android:translationX="12dp"
                     android:visibility="gone"

--- a/app/src/main/res/layout/activity_manage_accounts.xml
+++ b/app/src/main/res/layout/activity_manage_accounts.xml
@@ -14,12 +14,10 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
             app:contentInsetStartWithNavigation="0dp"
             app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
             app:title="@string/manage_accounts"
-            app:titleMarginStart="0dp"
-            app:titleTextColor="@android:color/white" />
+            app:titleMarginStart="0dp" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/activity_prepare_create.xml
+++ b/app/src/main/res/layout/activity_prepare_create.xml
@@ -15,8 +15,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?android:actionBarSize"
-            app:title="@string/add_card"
-            app:titleTextColor="@android:color/white" />
+            app:title="@string/add_card" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView

--- a/app/src/main/res/layout/activity_push_notification.xml
+++ b/app/src/main/res/layout/activity_push_notification.xml
@@ -21,8 +21,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?android:actionBarSize"
                 app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
-                app:title="@string/app_name"
-                app:titleTextColor="@android:color/white" />
+                app:title="@string/app_name" />
         </com.google.android.material.appbar.AppBarLayout>
 
         <ProgressBar

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -15,8 +15,7 @@
             android:layout_width="match_parent"
             android:layout_height="?android:actionBarSize"
             app:navigationIcon="@drawable/ic_arrow_back_white_24dp"
-            app:title="@string/simple_settings"
-            app:titleTextColor="@android:color/white" />
+            app:title="@string/simple_settings" />
     </com.google.android.material.appbar.AppBarLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_board_manage_labels.xml
+++ b/app/src/main/res/layout/dialog_board_manage_labels.xml
@@ -29,7 +29,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:contentDescription="@string/add_comment"
-            android:tint="@android:color/white"
+            app:backgroundTint="@color/defaultBrand"
             app:fabSize="mini"
             app:srcCompat="@drawable/ic_send_white_24dp" />
     </LinearLayout>

--- a/app/src/main/res/layout/dialog_filter.xml
+++ b/app/src/main/res/layout/dialog_filter.xml
@@ -9,7 +9,10 @@
         android:id="@+id/tab_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:tabIndicatorColor="@color/defaultBrand"
         app:tabInlineLabel="true"
+        app:tabMode="fixed"
+        app:tabTextColor="@color/accent"
         app:tabUnboundedRipple="true" />
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/dialog_filter.xml
+++ b/app/src/main/res/layout/dialog_filter.xml
@@ -12,7 +12,7 @@
         app:tabIndicatorColor="@color/defaultBrand"
         app:tabInlineLabel="true"
         app:tabMode="fixed"
-        app:tabTextColor="@color/accent"
+        app:tabTextColor="?attr/colorAccent"
         app:tabUnboundedRipple="true" />
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/fragment_about_license_tab.xml
+++ b/app/src/main/res/layout/fragment_about_license_tab.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -26,7 +27,8 @@
             style="@style/Widget.MaterialComponents.Button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/about_app_license_button" />
+            android:text="@string/about_app_license_button"
+            app:backgroundTint="@color/defaultBrand" />
 
         <TextView
             style="?android:attr/listSeparatorTextViewStyle"

--- a/app/src/main/res/layout/fragment_card_edit_tab_attachments.xml
+++ b/app/src/main/res/layout/fragment_card_edit_tab_attachments.xml
@@ -32,7 +32,7 @@
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
         android:visibility="gone"
-        app:backgroundTint="@color/primary"
+        app:backgroundTint="@color/defaultBrand"
         app:srcCompat="@drawable/ic_file_upload_white_24dp"
         tools:visibility="visible" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_card_edit_tab_comments.xml
+++ b/app/src/main/res/layout/fragment_card_edit_tab_comments.xml
@@ -114,7 +114,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:contentDescription="@string/add_comment"
-                android:tint="@android:color/white"
+                app:backgroundTint="@color/defaultBrand"
                 app:fabSize="mini"
                 app:srcCompat="@drawable/ic_send_white_24dp" />
         </LinearLayout>

--- a/app/src/main/res/layout/item_card.xml
+++ b/app/src/main/res/layout/item_card.xml
@@ -146,6 +146,7 @@
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:contentDescription="@string/label_menu"
                     android:padding="@dimen/spacer_1hx"
+                    android:tint="@color/accent"
                     app:srcCompat="@drawable/ic_menu" />
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/item_card.xml
+++ b/app/src/main/res/layout/item_card.xml
@@ -9,6 +9,7 @@
     android:layout_marginTop="@dimen/spacer_1x"
     android:layout_marginEnd="@dimen/spacer_2x"
     android:layout_marginBottom="@dimen/spacer_1x"
+    app:cardBackgroundColor="@color/bg_card"
     android:focusable="true">
 
     <LinearLayout

--- a/app/src/main/res/layout/item_card.xml
+++ b/app/src/main/res/layout/item_card.xml
@@ -33,6 +33,7 @@
                 android:layout_marginTop="4sp"
                 android:layout_weight="1"
                 android:textSize="18sp"
+                android:textColor="?attr/colorAccent"
                 tools:ignore="RtlSymmetry"
                 tools:text="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut l" />
 

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -4,7 +4,7 @@
     android:id="@+id/header_view"
     android:layout_width="match_parent"
     android:layout_height="@dimen/drawer_header_height"
-    android:background="@color/primary">
+    android:background="@color/defaultBrand">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/logo"
@@ -14,6 +14,7 @@
         android:layout_margin="@dimen/spacer_2x"
         android:gravity="center"
         android:padding="@dimen/spacer_1hx"
+        android:tint="@android:color/white"
         app:srcCompat="@drawable/ic_app_logo" />
 
     <TextView
@@ -26,5 +27,6 @@
         android:fontFamily="sans-serif-light"
         android:gravity="center_vertical"
         android:text="@string/app_name_short"
+        android:textColor="@android:color/white"
         android:textSize="24sp" />
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -26,6 +26,5 @@
         android:fontFamily="sans-serif-light"
         android:gravity="center_vertical"
         android:text="@string/app_name_short"
-        android:textColor="@android:color/white"
         android:textSize="24sp" />
 </RelativeLayout>

--- a/app/src/main/res/values-night/booleans.xml
+++ b/app/src/main/res/values-night/booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isDayMode">false</bool>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="primary">#121212</color>
+    <color name="accent">#ffffff</color>
     <color name="fg_secondary">#666</color>
     <color name="bg_highlighted">#2a2a2a</color>
     <color name="bg_info_box">#222222</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -5,7 +5,7 @@
     <color name="fg_secondary">#666</color>
     <color name="bg_highlighted">#2a2a2a</color>
     <color name="bg_info_box">#222222</color>
-    <color name="avatars_overlapping_border_color">#424242</color>
+    <color name="bg_card">#212121</color>
 
     <color name="widget_background">#cc212121</color>
     <color name="widget_foreground">#ccf5f5f5</color>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="BaseTheme">
+        <item name="android:windowLightStatusBar">@bool/isDayMode</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="BaseTheme">
+        <item name="android:windowLightStatusBar">@bool/isDayMode</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+        <item name="android:navigationBarColor">?attr/colorPrimary</item>
+        <item name="android:windowLightNavigationBar">@bool/isDayMode</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,6 +8,4 @@
         <attr name="description" format="string" />
         <attr name="image" format="reference" />
     </declare-styleable>
-    <attr name="toolbarEditTextColor" format="reference" />
-    <attr name="toolbarEditTextHighlightColor" format="reference" />
 </resources>

--- a/app/src/main/res/values/booleans.xml
+++ b/app/src/main/res/values/booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isDayMode">true</bool>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,8 +11,7 @@
     <color name="bg_highlighted">#eee</color>
     <color name="grey600">#757575</color>
     <color name="bg_info_box">#dddddd</color>
-
-    <color name="avatars_overlapping_border_color">#ffffff</color>
+    <color name="bg_card">#ffffff</color>
 
     <color name="dark_fg_primary">#e5e5e5</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primary">#ffffff</color>
-    <color name="accent">#121212</color>
+    <color name="accent">#000000</color>
     <color name="toolbarEditTextHighlightColor">#55ffffff</color>
     <color name="danger">#d40000</color>
     <color name="fg_accent">#fff</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="primary">#0082c9</color>
-    <color name="accent">#ffffff</color>
+    <color name="primary">#ffffff</color>
+    <color name="accent">#121212</color>
     <color name="toolbarEditTextHighlightColor">#55ffffff</color>
     <color name="danger">#d40000</color>
     <color name="fg_accent">#fff</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="primary">#ffffff</color>
     <color name="accent">#000000</color>
+    <color name="defaultBrand">#0082C9</color>
     <color name="toolbarEditTextHighlightColor">#55ffffff</color>
     <color name="danger">#d40000</color>
     <color name="fg_accent">#fff</color>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -4,7 +4,6 @@
     <string name="shared_preference_last_background_sync" translatable="false">it.niedermann.nextcloud.deck.last_background_sync</string>
 
     <string name="shared_preference_theme_main" translatable="false">it.niedermann.nextcloud.deck.theme_main</string>
-    <string name="shared_preference_theme_text" translatable="false">it.niedermann.nextcloud.deck.theme_text</string>
 
     <string name="pref_key_wifi_only" translatable="false">wifiOnly</string>
     <string name="pref_key_dark_theme" translatable="false">darkTheme</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,6 +4,11 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary</item>
         <item name="colorAccent">@color/accent</item>
+        <item name="toolbarStyle">@style/toolbarStyle</item>
+    </style>
+
+    <style name="toolbarStyle" parent="@style/Widget.AppCompat.Toolbar">
+        <item name="android:background">?attr/colorPrimary</item>
     </style>
 
     <!-- Default is a light theme with the dark blue brand -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,7 +17,7 @@
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/splash_screen</item>
-        <item name="colorPrimaryDark">@color/primary</item>
+        <item name="colorPrimaryDark">@color/defaultBrand</item>
     </style>
 
     <style name="NavigationView">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,12 +1,13 @@
 <resources>
 
-    <!-- Default is a light theme with the dark blue brand -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
+    <style name="BaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary</item>
-        <item name="colorAccent">@color/primary</item>
-        <item name="colorControlNormal">?attr/colorAccent</item>
+        <item name="colorAccent">@color/accent</item>
     </style>
+
+    <!-- Default is a light theme with the dark blue brand -->
+    <style name="AppTheme" parent="BaseTheme" />
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/splash_screen</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <item name="colorPrimaryDark">@color/primary</item>
         <item name="colorAccent">@color/accent</item>
         <item name="toolbarStyle">@style/toolbarStyle</item>
+        <item name="android:windowBackground">?attr/colorPrimary</item>
     </style>
 
     <style name="toolbarStyle" parent="@style/Widget.AppCompat.Toolbar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,32 +1,11 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <!-- Default is a light theme with the dark blue brand -->
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary</item>
         <item name="colorAccent">@color/primary</item>
-        <item name="toolbarEditTextColor">@android:color/white</item>
-        <item name="toolbarEditTextHighlightColor">@color/toolbarEditTextHighlightColor</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:elevation" tools:targetApi="lollipop">@null</item>
-    </style>
-
-    <!-- This is a light theme with a bright brand color like yellow -->
-    <style name="AppThemeLightBrand" parent="AppTheme">
-        <item name="toolbarEditTextColor">@android:color/black</item>
-    </style>
-
-    <!-- This styles an EditText which is on a primary background like in the toolbar -->
-    <style name="EditTextOnPrimaryBackground" parent="ThemeOverlay.MaterialComponents.Dark">
-        <item name="android:textColor">?toolbarEditTextColor</item>
-        <item name="android:textColorHighlight">?toolbarEditTextHighlightColor</item>
-        <item name="colorControlNormal">?toolbarEditTextColor</item>
-        <item name="colorControlActivated">?toolbarEditTextColor</item>
-        <item name="colorControlHighlight">?toolbarEditTextColor</item>
-    </style>
-
-    <style name="DarkTextView" parent="Widget.AppCompat.TextView">
-        <item name="android:textColor">@color/dark_fg_primary</item>
+        <item name="colorControlNormal">?attr/colorAccent</item>
     </style>
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">


### PR DESCRIPTION
Partially solve #525: This will adjust especially the toolbar colors etc. This will **not** use the board color as primary brand color.

- [x] Migration: remove context.getString(R.string.shared_preference_theme_text)
- [x] Tint progress bars
  - [x] Import account
  - [x] Upload attachments
  - [x] Pull 2 Refresh
- [x] Branding
  - [x] Light theme
    - [x] Dark brand colors
    - [x] Light brand colors
  - [x] Dark theme
    - [x] Dark brand colors
    - [x] Light brand colors
- [x] No branding
  - [x] Light theme
    - [x] Dark brand colors
    - [x] Light brand colors
  - [x] Dark theme
    - [x] Dark brand colors
    - [x] Light brand colors