### PR TITLE
Java 8 core library desugaring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
     flavorDimensions "version"
     productFlavors {
@@ -82,9 +83,6 @@ dependencies {
     // Custom Date / Time Picker for branding support
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
 
-    // Android backport for java.time
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.4'
-
     // Flexbox
     implementation 'com.google.android:flexbox:2.0.1'
 
@@ -120,7 +118,7 @@ dependencies {
     // -----------------------
 
     implementation 'androidx.multidex:multidex:2.0.1'
-
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
 
     // -------------
     // --- Tests ---

--- a/app/src/main/java/it/niedermann/nextcloud/deck/DeckApplication.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/DeckApplication.java
@@ -1,20 +1,17 @@
 package it.niedermann.nextcloud.deck;
 
-import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
+import androidx.multidex.MultiDexApplication;
 import androidx.preference.PreferenceManager;
-
-import com.jakewharton.threetenabp.AndroidThreeTen;
 
 import static androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO;
 import static androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES;
 import static androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode;
-import static androidx.multidex.MultiDex.install;
 
-public class DeckApplication extends Application {
+public class DeckApplication extends MultiDexApplication {
 
     public static final long NO_ACCOUNT_ID = -1L;
     public static final long NO_BOARD_ID = -1L;
@@ -24,17 +21,6 @@ public class DeckApplication extends Application {
     public void onCreate() {
         setAppTheme(isDarkTheme(getApplicationContext()));
         super.onCreate();
-        AndroidThreeTen.init(this);
-    }
-
-    // --------
-    // Multidex
-    // --------
-
-    @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        install(this);
     }
 
     // -----------------

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
@@ -6,10 +6,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import org.threeten.bp.DateTimeUtils;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.format.DateTimeFormatter;
-
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -650,7 +648,7 @@ public class JsonToEntityParser {
             return null;
         } else {
             String dateAsString = jsonElement.getAsString();
-            return DateTimeUtils.toDate(ZonedDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(dateAsString)).toInstant());
+            return new Date(ZonedDateTime.from(DateTimeFormatter.ISO_DATE_TIME.parse(dateAsString)).toInstant().toEpochMilli());
         }
     }
 


### PR DESCRIPTION
- Remove `com.jakewharton.threetenabp` dependency (Fix #713)
- Enable core library desugaring
  - Sequential streams (`java.util.stream`)
  - A subset of `java.time`
  - `java.util.function`
  - Recent additions to `java.util.{Map,Collection,Comparator}`
  - `Optionals` (`java.util.Optional`, `java.util.OptionalInt` and `java.util.OptionalDouble`) and some other new classes useful with the above APIs
  - Some additions to `java.util.concurrent.atomic` (new methods on `AtomicInteger`, `AtomicLong` and `AtomicReference`)
  - `ConcurrentHashMap` (with bug fixes for Android 5.0)
  - ... [complete list of all enabled APIs](https://developer.android.com/studio/write/java8-support-table)

- [x] Test setting a new due date / time in the app and sync up to the server
- [x] Test setting a new due date / time at the server and sync down to the app
- [x] Test on old Android 4.4 device