### PR TITLE
Dark mode following system default (fix #392)

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/DarkModeSetting.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/DarkModeSetting.java
@@ -1,0 +1,52 @@
+package it.niedermann.nextcloud.deck.ui.settings;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatDelegate;
+
+import it.niedermann.nextcloud.deck.R;
+
+/**
+ * Possible values of the Dark Mode Setting.
+ * <p>
+ * The Dark Mode Setting can be stored in {@link android.content.SharedPreferences} as String by using {@link DarkModeSetting#getPreferenceValue(Context)} and received via {@link DarkModeSetting#valueOf(String)}.
+ * <p>
+ * Additionally, the equivalent {@link AppCompatDelegate}-Mode can be received via {@link #getModeId()}.
+ *
+ * @see AppCompatDelegate#MODE_NIGHT_YES
+ * @see AppCompatDelegate#MODE_NIGHT_NO
+ * @see AppCompatDelegate#MODE_NIGHT_FOLLOW_SYSTEM
+ */
+public enum DarkModeSetting {
+
+    /**
+     * Always use light mode.
+     */
+    LIGHT(AppCompatDelegate.MODE_NIGHT_NO, R.string.pref_value_theme_light),
+    /**
+     * Always use dark mode.
+     */
+    DARK(AppCompatDelegate.MODE_NIGHT_YES, R.string.pref_value_theme_dark),
+    /**
+     * Follow the global system setting for dark mode.
+     */
+    SYSTEM_DEFAULT(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, R.string.pref_value_theme_system_default);
+
+    private final int modeId;
+    private final @StringRes int preferenceValue;
+
+    DarkModeSetting(int modeId, @StringRes int preferenceValue) {
+        this.modeId = modeId;
+        this.preferenceValue = preferenceValue;
+    }
+
+    public int getModeId() {
+        return modeId;
+    }
+
+    public String getPreferenceValue(@NonNull Context context) {
+        return context.getString(preferenceValue);
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
@@ -21,7 +21,6 @@ import static it.niedermann.nextcloud.deck.ui.branding.BrandingUtil.readBrandMai
 public class SettingsFragment extends PreferenceFragmentCompat implements Branded {
 
     private BrandedSwitchPreference wifiOnlyPref;
-    private BrandedSwitchPreference themePref;
     private BrandedSwitchPreference brandingPref;
     private BrandedSwitchPreference compactPref;
 
@@ -41,11 +40,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Brande
             DeckLog.error("Could not find preference with key: \"" + getString(R.string.pref_key_wifi_only) + "\"");
         }
 
-        themePref = findPreference(getString(R.string.pref_key_dark_theme));
+        Preference themePref = findPreference(getString(R.string.pref_key_dark_theme));
         if (themePref != null) {
             themePref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
-                final Boolean darkTheme = (Boolean) newValue;
-                DeckLog.log("darkTheme: " + darkTheme);
+                final DarkModeSetting darkTheme = DarkModeSetting.valueOf((String) newValue);
+                DeckLog.log("appTheme: " + darkTheme);
                 setAppTheme(darkTheme);
                 requireActivity().setResult(Activity.RESULT_OK);
                 requireActivity().recreate();
@@ -93,7 +92,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Brande
     @Override
     public void applyBrand(int mainColor) {
         wifiOnlyPref.applyBrand(mainColor);
-        themePref.applyBrand(mainColor);
         brandingPref.applyBrand(mainColor);
         compactPref.applyBrand(mainColor);
     }

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -30,6 +30,16 @@
         <item>@string/pref_value_background_6_hours</item>
     </string-array>
 
+    <string name="pref_value_theme_light" translatable="false">LIGHT</string>
+    <string name="pref_value_theme_dark" translatable="false">DARK</string>
+    <string name="pref_value_theme_system_default" translatable="false">SYSTEM_DEFAULT</string>
+
+    <string-array name="darkMode_values">
+        <item>@string/pref_value_theme_light</item>
+        <item>@string/pref_value_theme_dark</item>
+        <item>@string/pref_value_theme_system_default</item>
+    </string-array>
+
     <!-- To be concatenated with the account id -->
     <string name="shared_preference_last_account" translatable="false">it.niedermann.nextcloud.deck.last_account</string>
     <string name="shared_preference_last_board_for_account_" translatable="false">it.niedermann.nextcloud.deck.last_board_for_account_</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,13 +148,17 @@
     <string name="your_deck_version_is_too_old">Your deck version is too old</string>
     <string name="deck_outdated_please_update">Your deck version is too old (%1$s). Please update to use this android app as client.</string>
     <string name="delete_board_message">This will permanently delete this board including all lists and cards.</string>
-    <string name="settings_theme_title">Dark theme</string>
+    <string name="settings_theme_title">Theme</string>
     <string name="settings_branding_title">Branding</string>
     <string name="settings_compact_title">Compact mode</string>
     <string name="settings_background_sync">Background synchronization</string>
     <string name="pref_value_wifi_and_mobile">Sync on Wi-Fi and mobile data</string>
     <string name="pref_value_wifi_only">Sync only on Wi-Fi</string>
-    <string name="pref_value_theme_light">Light</string>
+    <string-array name="darkmode_entries">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>System Default</item>
+    </string-array>
     <string name="unassigned_user">Unassigned %1$s</string>
     <string name="no_activities">There are no activities on this card. You need to be connected to the internet to load and display activities.</string>
     <string name="share_board">Share board</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -19,10 +19,13 @@
     </it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory>
 
     <it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory android:title="@string/simple_appearance">
-        <it.niedermann.nextcloud.deck.ui.branding.BrandedSwitchPreference
-            android:defaultValue="@string/pref_value_theme_light"
+        <ListPreference
+            android:defaultValue="@string/pref_value_theme_system_default"
+            android:entries="@array/darkmode_entries"
+            android:entryValues="@array/darkMode_values"
             android:icon="@drawable/ic_brightness_2_grey600_24dp"
             android:key="@string/pref_key_dark_theme"
+            android:summary="%s"
             android:title="@string/settings_theme_title" />
 
         <it.niedermann.nextcloud.deck.ui.branding.BrandedSwitchPreference


### PR DESCRIPTION
Based on the code which is used for the Notes app, I implemented the same theme selection for Decks (resolves #392). AFAIK the code is completely working and could be merged... Feedback is very welcome! 

![grafik](https://user-images.githubusercontent.com/64581222/101947365-a3217200-3bf0-11eb-80c6-91f5e0fcb347.png)
