### PR TITLE
Highlight current board in drawer

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -654,6 +654,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                 startActivity(ArchivedBoardsActvitiy.createIntent(MainActivity.this, mainViewModel.getCurrentAccount()));
                 break;
             default:
+                binding.navigationView.setCheckedItem(item);
                 setCurrentBoard(boardsList.get(item.getItemId()));
                 break;
         }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedboards/ArchivedBoardsActvitiy.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/archivedboards/ArchivedBoardsActvitiy.java
@@ -119,6 +119,12 @@ public class ArchivedBoardsActvitiy extends BrandedActivity implements DeleteBoa
 
     @Override
     public void onClone(Board board) {
+        throw new IllegalStateException("Cloning boards is not available at " + ArchivedBoardsActvitiy.class.getSimpleName());
+    }
 
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish(); // close this activity as oppose to navigating up
+        return true;
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -176,6 +176,12 @@ public class EditActivity extends BrandedActivity {
         return super.onOptionsItemSelected(item);
     }
 
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish(); // close this activity as oppose to navigating up
+        return true;
+    }
+
     /**
      * Tries to save the current {@link FullCard} from the {@link EditCardViewModel} and then finishes this activity.
      */

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/DrawerMenuUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/DrawerMenuUtil.java
@@ -39,7 +39,9 @@ public class DrawerMenuUtil {
         SubMenu boardsMenu = menu.addSubMenu(R.string.simple_boards);
         int index = 0;
         for (Board board : boards) {
-            MenuItem m = boardsMenu.add(Menu.NONE, index++, Menu.NONE, board.getTitle()).setIcon(ViewUtil.getTintedImageView(context, R.drawable.circle_grey600_36dp, board.getColor()));
+            MenuItem m = boardsMenu
+                    .add(Menu.NONE, index++, Menu.NONE, board.getTitle()).setIcon(ViewUtil.getTintedImageView(context, R.drawable.circle_grey600_36dp, board.getColor()))
+                    .setCheckable(true);
             if (currentServerVersionIsSupported) {
                 if (board.isPermissionManage()) {
                     AppCompatImageButton contextMenu = new AppCompatImageButton(context);

--- a/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?colorControlHighlight">
+
+    <item
+        android:id="@android:id/mask"
+        android:left="@dimen/spacer_1x"
+        android:right="@dimen/spacer_1x">
+
+        <shape android:shape="rectangle">
+            <!-- value of color is irrelevant, but solid needs to be defined for mask to work -->
+            <solid android:color="@color/bg_highlighted" />
+            <corners android:radius="@dimen/spacer_1hx" />
+        </shape>
+    </item>
+
+    <item
+        android:left="@dimen/spacer_1x"
+        android:right="@dimen/spacer_1x">
+
+        <selector>
+            <item android:state_selected="true">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/spacer_1hx" />
+                    <solid android:color="@color/bg_highlighted" />
+                </shape>
+            </item>
+
+            <item>
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/spacer_1hx" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+
+</ripple>

--- a/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
@@ -19,7 +19,7 @@
         android:right="@dimen/spacer_1x">
 
         <selector>
-            <item android:state_selected="true">
+            <item android:state_checked="true">
                 <shape android:shape="rectangle">
                     <corners android:radius="@dimen/spacer_1hx" />
                     <solid android:color="@color/bg_highlighted" />

--- a/app/src/main/res/drawable/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable/bg_navdrawer_item.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" android:left="@dimen/spacer_1x" android:right="@dimen/spacer_1x">
+
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/bg_highlighted" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle" />
+    </item>
+
+</selector>

--- a/app/src/main/res/drawable/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable/bg_navdrawer_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" android:left="@dimen/spacer_1x" android:right="@dimen/spacer_1x">
 
-    <item android:state_selected="true">
+    <item android:state_checked="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/bg_highlighted" />
         </shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -221,6 +221,7 @@
         android:fitsSystemWindows="false"
         android:theme="@style/NavigationView"
         app:headerLayout="@layout/nav_header_main"
-        app:itemBackground="@drawable/bg_navdrawer_item" />
+        app:itemBackground="@drawable/bg_navdrawer_item"
+        app:itemTextColor="?attr/colorOnSurface" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -220,6 +220,7 @@
         android:background="?attr/colorPrimary"
         android:fitsSystemWindows="false"
         android:theme="@style/NavigationView"
-        app:headerLayout="@layout/nav_header_main" />
+        app:headerLayout="@layout/nav_header_main"
+        app:itemBackground="@drawable/bg_navdrawer_item" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -6,4 +6,11 @@
         <item name="android:navigationBarColor">@color/primary</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
+
+    <style name="NavigationView">
+        <!-- https://github.com/stefan-niedermann/nextcloud-deck/issues/444 -->
+        <item name="android:ellipsize">end</item>
+        <item name="android:listDivider">@null</item>
+        <item name="android:colorControlHighlight">@android:color/transparent</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-v24/styles.xml
+++ b/app/src/main/res/values-v24/styles.xml
@@ -4,5 +4,6 @@
     <style name="NavigationView">
         <item name="android:ellipsize">middle</item>
         <item name="android:listDivider">@null</item>
+        <item name="android:colorControlHighlight">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
Fix #769 

@thgoebel i am not sure whether or not you are also using the Deck app, but since you implemented the same stuff for the Notes app i wanted to ask you whether you would like to help me with the same change here? I tried to adapt the changes you made in the Notes app, but i have troubles with the checked/selected state colors in the `NavigationDrawer`. Is it an issue that i don't use a custom layout here like for the items in the Notes app? (I actually tried to avoid a custom layout here...)