### PR TITLE
Enhance support for file attachments (Deck 1.3.0)

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI.java
@@ -132,12 +132,12 @@ public interface DeckAPI {
     Observable<List<Attachment>> getAttachments(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId);
 
     @Multipart
-    @POST("boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments?type=deck_file")
-    Observable<Attachment> uploadAttachment(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId,  @Part MultipartBody.Part type, @Part MultipartBody.Part attachment);
+    @POST("boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments")
+    Observable<Attachment> uploadAttachment(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId, @Part MultipartBody.Part type, @Part MultipartBody.Part attachment);
 
     @Multipart
-    @PUT("boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments?type=deck_file")
-    Observable<Attachment>  updateAttachment(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId, @Path("attachmentId") long attachmentId, @Part MultipartBody.Part type, @Part MultipartBody.Part attachment);
+    @PUT("boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments")
+    Observable<Attachment> updateAttachment(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId, @Path("attachmentId") long attachmentId, @Part MultipartBody.Part type, @Part MultipartBody.Part attachment);
 
     @DELETE("boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments/{attachmentId}")
     Observable<Void> deleteAttachment(@Path("boardId") long boardId, @Path("stackId") long stackId, @Path("cardId") long cardId, @Path("attachmentId") long attachmentId);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
@@ -469,6 +469,7 @@ public class JsonToEntityParser {
                 JsonObject extendedData = e.getAsJsonObject("extendedData").getAsJsonObject();
                 a.setFilesize(extendedData.get("filesize").getAsLong());
                 a.setMimetype(extendedData.get("mimetype").getAsString());
+                a.setFileid(extendedData.get("fileid").getAsLong());
                 if (extendedData.has("info") && !extendedData.get("info").isJsonNull()) {
                     JsonObject info = extendedData.getAsJsonObject("info").getAsJsonObject();
                     a.setDirname(info.get("dirname").getAsString());

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
@@ -23,6 +23,7 @@ import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.model.Stack;
 import it.niedermann.nextcloud.deck.model.User;
 import it.niedermann.nextcloud.deck.model.enums.ActivityType;
+import it.niedermann.nextcloud.deck.model.enums.EAttachmentType;
 import it.niedermann.nextcloud.deck.model.full.FullBoard;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
 import it.niedermann.nextcloud.deck.model.full.FullStack;
@@ -457,7 +458,7 @@ public class JsonToEntityParser {
         makeTraceableIfFails(() -> {
             a.setId(e.get("id").getAsLong());
             a.setCardId(e.get("cardId").getAsLong());
-            a.setType(e.get("type").getAsString());
+            a.setType(EAttachmentType.findByValue(e.get("type").getAsString()));
             a.setEtag(getNullAsNull(e.get("ETag")));
             a.setData(e.get("data").getAsString());
             a.setLastModified(getTimestampFromLong(e.get("lastModified")));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/JsonToEntityParser.java
@@ -469,7 +469,9 @@ public class JsonToEntityParser {
                 JsonObject extendedData = e.getAsJsonObject("extendedData").getAsJsonObject();
                 a.setFilesize(extendedData.get("filesize").getAsLong());
                 a.setMimetype(extendedData.get("mimetype").getAsString());
-                a.setFileid(extendedData.get("fileid").getAsLong());
+                if (extendedData.has("fileid") && !extendedData.get("fileid").isJsonNull()) {
+                    a.setFileId(extendedData.get("fileid").getAsLong());
+                }
                 if (extendedData.has("info") && !extendedData.get("info").isJsonNull()) {
                     JsonObject info = extendedData.getAsJsonObject("info").getAsJsonObject();
                     a.setDirname(info.get("dirname").getAsString());

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/Attachment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/Attachment.java
@@ -1,8 +1,8 @@
 package it.niedermann.nextcloud.deck.model;
 
+import androidx.annotation.Nullable;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
-import androidx.room.Ignore;
 import androidx.room.Index;
 
 import java.io.Serializable;
@@ -38,9 +38,8 @@ public class Attachment extends AbstractRemoteEntity implements Comparable<Attac
     private String extension;
     private String filename;
     private String localPath;
-    // TODO should probably be a Long... depends on https://github.com/nextcloud/deck/pull/2638
-    @Ignore
-    private String fileId;
+    @Nullable
+    private Long fileid;
 
     public long getCardId() {
         return cardId;
@@ -146,20 +145,13 @@ public class Attachment extends AbstractRemoteEntity implements Comparable<Attac
         this.localPath = localPath;
     }
 
-    /**
-     * TODO depends on https://github.com/nextcloud/deck/pull/2638
-     */
-    @Ignore
-    public String getFileId() {
-        return this.fileId;
+    @Nullable
+    public Long getFileid() {
+        return this.fileid;
     }
 
-    /**
-     * TODO depends on https://github.com/nextcloud/deck/pull/2638
-     */
-    @Ignore
-    public void setFileId(String fileId) {
-        this.fileId = fileId;
+    public void setFileid(@Nullable Long fileid) {
+        this.fileid = fileid;
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/Attachment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/Attachment.java
@@ -39,7 +39,7 @@ public class Attachment extends AbstractRemoteEntity implements Comparable<Attac
     private String filename;
     private String localPath;
     @Nullable
-    private Long fileid;
+    private Long fileId;
 
     public long getCardId() {
         return cardId;
@@ -146,12 +146,12 @@ public class Attachment extends AbstractRemoteEntity implements Comparable<Attac
     }
 
     @Nullable
-    public Long getFileid() {
-        return this.fileid;
+    public Long getFileId() {
+        return this.fileId;
     }
 
-    public void setFileid(@Nullable Long fileid) {
-        this.fileid = fileid;
+    public void setFileId(@Nullable Long fileId) {
+        this.fileId = fileId;
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/Attachment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/Attachment.java
@@ -8,6 +8,7 @@ import androidx.room.Index;
 import java.io.Serializable;
 import java.time.Instant;
 
+import it.niedermann.nextcloud.deck.model.enums.EAttachmentType;
 import it.niedermann.nextcloud.deck.model.interfaces.AbstractRemoteEntity;
 
 @Entity(inheritSuperIndices = true,
@@ -24,7 +25,8 @@ import it.niedermann.nextcloud.deck.model.interfaces.AbstractRemoteEntity;
 public class Attachment extends AbstractRemoteEntity implements Comparable<Attachment>, Serializable {
 
     private long cardId;
-    private String type = "deck_file";
+    // TODO use EAttachmentType
+    private EAttachmentType type = EAttachmentType.DECK_FILE;
     private String data;
     private Instant createdAt;
     private String createdBy;
@@ -48,11 +50,11 @@ public class Attachment extends AbstractRemoteEntity implements Comparable<Attac
         this.cardId = cardId;
     }
 
-    public String getType() {
+    public EAttachmentType getType() {
         return type;
     }
 
-    public void setType(String type) {
+    public void setType(EAttachmentType type) {
         this.type = type;
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/enums/EAttachmentType.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/enums/EAttachmentType.java
@@ -3,7 +3,8 @@ package it.niedermann.nextcloud.deck.model.enums;
 public enum EAttachmentType {
     // Do not change values. They match the Deck server apps values.
     DECK_FILE(1, "deck_file"),
-    FILE(2, "file");
+    FILE(2, "file"),
+    UNKNOWN(1337, "unknown");
 
     private final int id;
     private final String value;
@@ -23,7 +24,7 @@ public enum EAttachmentType {
                 return s;
             }
         }
-        throw new IllegalArgumentException("unknown " + EAttachmentType.class.getSimpleName() + " value: " + value);
+        return UNKNOWN;
     }
 
     public String getValue() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/enums/EAttachmentType.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/enums/EAttachmentType.java
@@ -1,0 +1,32 @@
+package it.niedermann.nextcloud.deck.model.enums;
+
+public enum EAttachmentType {
+    // Do not change values. They match the Deck server apps values.
+    DECK_FILE(1, "deck_file"),
+    FILE(2, "file");
+
+    private final int id;
+    private final String value;
+
+    EAttachmentType(int id, String value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public static EAttachmentType findByValue(String value) {
+        for (EAttachmentType s : EAttachmentType.values()) {
+            if (s.value.equals(value)) {
+                return s;
+            }
+        }
+        throw new IllegalArgumentException("unknown " + EAttachmentType.class.getSimpleName() + " value: " + value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/ocs/Version.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/ocs/Version.java
@@ -1,9 +1,6 @@
 package it.niedermann.nextcloud.deck.model.ocs;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import java.util.regex.Matcher;
@@ -15,11 +12,10 @@ import it.niedermann.nextcloud.deck.model.ocs.comment.DeckComment;
 
 public class Version implements Comparable<Version> {
     private static final Pattern NUMBER_EXTRACTION_PATTERN = Pattern.compile("[0-9]+");
+    private static final Version VERSION_0_6_4 = new Version("0.6.4", 0, 6, 4);
     private static final Version VERSION_1_0_0 = new Version("1.0.0", 1, 0, 0);
     private static final Version VERSION_1_0_3 = new Version("1.0.3", 1, 0, 3);
     private static final Version VERSION_1_3_0 = new Version("1.3.0", 1, 3, 0);
-    @Nullable
-    private static Version VERSION_MINIMUM_SUPPORTED;
 
     private String originalVersion = "?";
     private int major = 0;
@@ -64,7 +60,7 @@ public class Version implements Comparable<Version> {
     public static Version of(String versionString) {
         int major = 0, minor = 0, micro = 0;
         if (versionString != null) {
-            String[] split = versionString.split("\\.");
+            final String[] split = versionString.split("\\.");
             if (split.length > 0) {
                 major = extractNumber(split[0]);
                 if (split.length > 1) {
@@ -87,18 +83,12 @@ public class Version implements Comparable<Version> {
     }
 
     @NonNull
-    public static Version minimumSupported(@NonNull Context context) {
-        if (VERSION_MINIMUM_SUPPORTED == null) {
-            final int minimumServerAppMajor = context.getResources().getInteger(R.integer.minimum_server_app_major);
-            final int minimumServerAppMinor = context.getResources().getInteger(R.integer.minimum_server_app_minor);
-            final int minimumServerAppPatch = context.getResources().getInteger(R.integer.minimum_server_app_patch);
-            VERSION_MINIMUM_SUPPORTED = new Version(minimumServerAppMajor + "." + minimumServerAppMinor + "." + minimumServerAppPatch, minimumServerAppMajor, minimumServerAppMinor, minimumServerAppPatch);
-        }
-        return VERSION_MINIMUM_SUPPORTED;
+    public static Version minimumSupported() {
+        return VERSION_0_6_4;
     }
 
-    public boolean isSupported(@NonNull Context context) {
-        return isGreaterOrEqualTo(Version.minimumSupported(context));
+    public boolean isSupported() {
+        return isGreaterOrEqualTo(minimumSupported());
     }
 
     /**

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/ocs/Version.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/ocs/Version.java
@@ -167,9 +167,7 @@ public class Version implements Comparable<Version> {
      * @see <a href="https://github.com/nextcloud/deck/pull/2638">documentation in PR</a>
      */
     public boolean supportsFileAttachments() {
-        return false;
-//         TODO depends on https://github.com/nextcloud/deck/pull/2638
-//         return isGreaterOrEqualTo(VERSION_1_3_0);
+        return isGreaterOrEqualTo(VERSION_1_3_0);
     }
 
     /**

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -215,7 +215,7 @@ public class SyncManager {
                 @Override
                 public void onResponse(Capabilities response) {
                     if (response != null && !response.isMaintenanceEnabled()) {
-                        if (response.getDeckVersion().isSupported(appContext)) {
+                        if (response.getDeckVersion().isSupported()) {
                             long accountId = callbackAccountId;
                             Instant lastSyncDate = LastSyncUtil.getLastSyncDate(callbackAccountId);
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/ServerAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/ServerAdapter.java
@@ -24,11 +24,13 @@ import it.niedermann.nextcloud.deck.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.api.RequestHelper;
 import it.niedermann.nextcloud.deck.exceptions.OfflineException;
 import it.niedermann.nextcloud.deck.model.AccessControl;
+import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.Attachment;
 import it.niedermann.nextcloud.deck.model.Board;
 import it.niedermann.nextcloud.deck.model.Card;
 import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.model.Stack;
+import it.niedermann.nextcloud.deck.model.enums.EAttachmentType;
 import it.niedermann.nextcloud.deck.model.full.FullBoard;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
 import it.niedermann.nextcloud.deck.model.full.FullStack;
@@ -281,10 +283,14 @@ public class ServerAdapter {
     }
 
     // ## ATTACHMENTS
-    public void uploadAttachment(Long remoteBoardId, long remoteStackId, long remoteCardId, String contentType, File attachment, IResponseCallback<Attachment> responseCallback) {
+    public void uploadAttachment(Long remoteBoardId, long remoteStackId, long remoteCardId, File attachment, IResponseCallback<Attachment> responseCallback) {
         ensureInternetConnection();
-        MultipartBody.Part filePart = MultipartBody.Part.createFormData("file", attachment.getName(), RequestBody.create(MediaType.parse(getMimeType(attachment)), attachment));
-        MultipartBody.Part typePart = MultipartBody.Part.createFormData("type", null, RequestBody.create(MediaType.parse(TEXT_PLAIN), "deck_file"));
+        final Account account = responseCallback.getAccount();
+        final String type = (account != null && account.getServerDeckVersionAsObject().supportsFileAttachments())
+                ? EAttachmentType.FILE.getValue()
+                : EAttachmentType.DECK_FILE.getValue();
+        final MultipartBody.Part filePart = MultipartBody.Part.createFormData("file", attachment.getName(), RequestBody.create(MediaType.parse(getMimeType(attachment)), attachment));
+        final MultipartBody.Part typePart = MultipartBody.Part.createFormData("type", null, RequestBody.create(MediaType.parse(TEXT_PLAIN), type));
         RequestHelper.request(provider, () -> provider.getDeckAPI().uploadAttachment(remoteBoardId, remoteStackId, remoteCardId, typePart, filePart), responseCallback);
     }
 
@@ -304,9 +310,13 @@ public class ServerAdapter {
 
     public void updateAttachment(Long remoteBoardId, long remoteStackId, long remoteCardId, long remoteAttachmentId, String contentType, Uri attachmentUri, IResponseCallback<Attachment> responseCallback) {
         ensureInternetConnection();
-        File attachment = new File(attachmentUri.getPath());
-        MultipartBody.Part filePart = MultipartBody.Part.createFormData("file", attachment.getName(), RequestBody.create(MediaType.parse(contentType), attachment));
-        MultipartBody.Part typePart = MultipartBody.Part.createFormData("type", attachment.getName(), RequestBody.create(MediaType.parse(TEXT_PLAIN), "deck_file"));
+        final File attachment = new File(attachmentUri.getPath());
+        final Account account = responseCallback.getAccount();
+        final String type = (account != null && account.getServerDeckVersionAsObject().supportsFileAttachments())
+                ? EAttachmentType.FILE.getValue()
+                : EAttachmentType.DECK_FILE.getValue();
+        final MultipartBody.Part filePart = MultipartBody.Part.createFormData("file", attachment.getName(), RequestBody.create(MediaType.parse(contentType), attachment));
+        final MultipartBody.Part typePart = MultipartBody.Part.createFormData("type", attachment.getName(), RequestBody.create(MediaType.parse(TEXT_PLAIN), type));
         RequestHelper.request(provider, () -> provider.getDeckAPI().updateAttachment(remoteBoardId, remoteStackId, remoteCardId, remoteAttachmentId, typePart, filePart), responseCallback);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DeckDatabase.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DeckDatabase.java
@@ -125,7 +125,7 @@ import it.niedermann.nextcloud.deck.persistence.sync.adapters.db.dao.widgets.fil
                 FilterWidgetSort.class,
         },
         exportSchema = false,
-        version = 27
+        version = 28
 )
 @TypeConverters({DateTypeConverter.class, EnumConverter.class})
 public abstract class DeckDatabase extends RoomDatabase {
@@ -506,6 +506,12 @@ public abstract class DeckDatabase extends RoomDatabase {
             database.execSQL("DROP TABLE `StackWidgetModel`");
         }
     };
+    private static final Migration MIGRATION_27_28 = new Migration(27, 28) {
+        @Override
+        public void migrate(SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE `Attachment` ADD COLUMN `fileId` INTEGER");
+        }
+    };
 
     public static final RoomDatabase.Callback ON_CREATE_CALLBACK = new RoomDatabase.Callback() {
         @Override
@@ -586,6 +592,7 @@ public abstract class DeckDatabase extends RoomDatabase {
                 .addMigrations(MIGRATION_24_25)
                 .addMigrations(MIGRATION_25_26)
                 .addMigrations(MIGRATION_26_27)
+                .addMigrations(MIGRATION_27_28)
                 .fallbackToDestructiveMigration()
                 .addCallback(ON_CREATE_CALLBACK)
                 .build();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/converter/EnumConverter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/converter/EnumConverter.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 import androidx.room.TypeConverter;
 
 import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.model.enums.EAttachmentType;
 import it.niedermann.nextcloud.deck.model.enums.EDueType;
 import it.niedermann.nextcloud.deck.model.enums.ESortCriteria;
 import it.niedermann.nextcloud.deck.model.widget.filter.EWidgetType;
@@ -49,5 +50,18 @@ public class EnumConverter {
     @Nullable
     public static Integer fromSortCriteriaEnum(@Nullable ESortCriteria value) {
         return value == null ? null : value.getId();
+    }
+
+    // #### EAttachmentType
+    @TypeConverter
+    @Nullable
+    public static EAttachmentType toEAttachmentType(@Nullable String value) {
+        return value == null ? null : EAttachmentType.findByValue(value);
+    }
+
+    @TypeConverter
+    @Nullable
+    public static String fromEAttachmentType(@Nullable EAttachmentType value) {
+        return value == null ? null : value.getValue();
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/DataPropagationHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/DataPropagationHelper.java
@@ -35,7 +35,7 @@ public class DataPropagationHelper {
         boolean connected = serverAdapter.hasInternetConnection();
         if (connected) {
             try {
-                provider.createOnServer(serverAdapter, dataBaseAdapter, accountId, new IResponseCallback<T>(new Account(accountId)) {
+                provider.createOnServer(serverAdapter, dataBaseAdapter, accountId, new IResponseCallback<T>(callback.getAccount()) {
                     @Override
                     public void onResponse(T response) {
                         new Thread(() -> {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/providers/AttachmentDataProvider.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/providers/AttachmentDataProvider.java
@@ -1,5 +1,6 @@
 package it.niedermann.nextcloud.deck.persistence.sync.helpers.providers;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
 
 import java.io.File;
@@ -67,7 +68,7 @@ public class AttachmentDataProvider extends AbstractSyncDataProvider<Attachment>
     @Override
     public void createOnServer(ServerAdapter serverAdapter, DataBaseAdapter dataBaseAdapter, long accountId, IResponseCallback<Attachment> responder, Attachment entity) {
         File file = new File(entity.getLocalPath());
-        serverAdapter.uploadAttachment(board.getId(), stack.getId(), card.getId(), entity.getType(), file, new IResponseCallback<Attachment>(responder.getAccount()) {
+        serverAdapter.uploadAttachment(board.getId(), stack.getId(), card.getId(), file, new IResponseCallback<Attachment>(responder.getAccount()) {
             @Override
             public void onResponse(Attachment response) {
                 if (file.delete()) {
@@ -77,6 +78,7 @@ public class AttachmentDataProvider extends AbstractSyncDataProvider<Attachment>
                 }
             }
 
+            @SuppressLint("MissingSuperCall")
             @Override
             public void onError(Throwable throwable) {
                 if (!file.delete()) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/ImportAccountActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/ImportAccountActivity.java
@@ -136,7 +136,7 @@ public class ImportAccountActivity extends AppCompatActivity {
                                     @Override
                                     public void onResponse(Capabilities response) {
                                         if (!response.isMaintenanceEnabled()) {
-                                            if (response.getDeckVersion().isSupported(getApplicationContext())) {
+                                            if (response.getDeckVersion().isSupported()) {
                                                 syncManager.synchronize(new IResponseCallback<Boolean>(account) {
                                                     @Override
                                                     public void onResponse(Boolean response) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -294,7 +294,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                 if (mainViewModel.isCurrentAccountIsSupportedVersion()) {
                     binding.infoBoxVersionNotSupported.setVisibility(View.GONE);
                 } else {
-                    binding.infoBoxVersionNotSupportedText.setText(getString(R.string.info_box_version_not_supported, mainViewModel.getCurrentAccount().getServerDeckVersion(), Version.minimumSupported(this).getOriginalVersion()));
+                    binding.infoBoxVersionNotSupportedText.setText(getString(R.string.info_box_version_not_supported, mainViewModel.getCurrentAccount().getServerDeckVersion(), Version.minimumSupported().getOriginalVersion()));
                     binding.infoBoxVersionNotSupportedText.setOnClickListener((v) -> {
                         Intent openURL = new Intent(Intent.ACTION_VIEW);
                         openURL.setData(Uri.parse(mainViewModel.getCurrentAccount().getUrl() + getString(R.string.url_fragment_update_deck)));
@@ -500,7 +500,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                     binding.swipeRefreshLayout.setRefreshing(false);
                 } else {
                     // If we notice after updating the capabilities, that the new version is not supported, but it was previously, recreate the activity to make sure all elements are disabled properly
-                    if (mainViewModel.getCurrentAccount().getServerDeckVersionAsObject().isSupported(MainActivity.this) && !response.getDeckVersion().isSupported(MainActivity.this)) {
+                    if (mainViewModel.getCurrentAccount().getServerDeckVersionAsObject().isSupported() && !response.getDeckVersion().isSupported()) {
                         ActivityCompat.recreate(MainActivity.this);
                     }
                 }
@@ -625,7 +625,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
         binding.navigationView.setItemIconTintList(null);
         Menu menu = binding.navigationView.getMenu();
         menu.clear();
-        DrawerMenuUtil.inflateBoards(this, menu, this.boardsList, mainViewModel.currentAccountHasArchivedBoards(), mainViewModel.getCurrentAccount().getServerDeckVersionAsObject().isSupported(this));
+        DrawerMenuUtil.inflateBoards(this, menu, this.boardsList, mainViewModel.currentAccountHasArchivedBoards(), mainViewModel.getCurrentAccount().getServerDeckVersionAsObject().isSupported());
         binding.navigationView.setCheckedItem(boardsList.indexOf(currentBoard));
     }
 
@@ -772,7 +772,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                                     @Override
                                     public void onResponse(Capabilities response) {
                                         if (!response.isMaintenanceEnabled()) {
-                                            if (response.getDeckVersion().isSupported(getApplicationContext())) {
+                                            if (response.getDeckVersion().isSupported()) {
                                                 runOnUiThread(() -> {
                                                     mainViewModel.setSyncManager(importSyncManager);
                                                     mainViewModel.setCurrentAccount(account);
@@ -796,7 +796,7 @@ public class MainActivity extends BrandedActivity implements DeleteStackListener
                                                     });
                                                 });
                                             } else {
-                                                DeckLog.warn("Cannot import account because server version is too low (" + response.getDeckVersion() + "). Minimum server version is currently " + Version.minimumSupported(getApplicationContext()));
+                                                DeckLog.warn("Cannot import account because server version is too low (" + response.getDeckVersion() + "). Minimum server version is currently " + Version.minimumSupported());
                                                 runOnUiThread(() -> new BrandedAlertDialogBuilder(MainActivity.this)
                                                         .setTitle(R.string.update_deck)
                                                         .setMessage(getString(R.string.deck_outdated_please_update, response.getDeckVersion().getOriginalVersion()))

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainViewModel.java
@@ -58,7 +58,7 @@ public class MainViewModel extends AndroidViewModel {
 
     public void setCurrentAccount(Account currentAccount) {
         this.currentAccount.setValue(currentAccount);
-        this.currentAccountIsSupportedVersion = currentAccount.getServerDeckVersionAsObject().isSupported(getApplication().getApplicationContext());
+        this.currentAccountIsSupportedVersion = currentAccount.getServerDeckVersionAsObject().isSupported();
     }
 
     public void setCurrentBoard(@NonNull Board currentBoard) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -124,7 +124,7 @@ public class EditActivity extends BrandedActivity {
             viewModel.setCanEdit(fullBoard.getBoard().isPermissionEdit());
             invalidateOptionsMenu();
             if (viewModel.isCreateMode()) {
-                viewModel.initializeNewCard(boardId, args.getLong(BUNDLE_KEY_STACK_ID), account.getServerDeckVersionAsObject().isSupported(this));
+                viewModel.initializeNewCard(boardId, args.getLong(BUNDLE_KEY_STACK_ID), account.getServerDeckVersionAsObject().isSupported());
                 invalidateOptionsMenu();
                 String title = args.getString(BUNDLE_KEY_TITLE);
                 if (!TextUtils.isEmpty(title)) {
@@ -145,7 +145,7 @@ public class EditActivity extends BrandedActivity {
                                 .setPositiveButton(R.string.simple_close, (a, b) -> super.finish())
                                 .show();
                     } else {
-                        viewModel.initializeExistingCard(boardId, fullCard, account.getServerDeckVersionAsObject().isSupported(this));
+                        viewModel.initializeExistingCard(boardId, fullCard, account.getServerDeckVersionAsObject().isSupported());
                         invalidateOptionsMenu();
                         setupViewPager();
                         setupTitle();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
@@ -42,7 +42,7 @@ public class AttachmentUtil {
     public static String getThumbnailUrl(@NonNull Version version, @NonNull String accountUrl, @NonNull Long cardRemoteId, @NonNull Attachment attachment, @Px int previewSize) {
         return version.supportsFileAttachments() &&
                 EAttachmentType.FILE.equals(attachment.getType()) &&
-                !TextUtils.isEmpty(attachment.getFileid())
+                attachment.getFileid() != null
                 ? accountUrl + "/index.php/core/preview?fileId=" + attachment.getFileid() + "&x=" + previewSize + "&y=" + previewSize
                 : getRemoteOrLocalUrl(accountUrl, cardRemoteId, attachment);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
@@ -42,8 +42,8 @@ public class AttachmentUtil {
     public static String getThumbnailUrl(@NonNull Version version, @NonNull String accountUrl, @NonNull Long cardRemoteId, @NonNull Attachment attachment, @Px int previewSize) {
         return version.supportsFileAttachments() &&
                 EAttachmentType.FILE.equals(attachment.getType()) &&
-                !TextUtils.isEmpty(attachment.getFileId())
-                ? accountUrl + "/index.php/core/preview?fileId=" + attachment.getFileId() + "&x=" + previewSize + "&y=" + previewSize
+                !TextUtils.isEmpty(attachment.getFileid())
+                ? accountUrl + "/index.php/core/preview?fileId=" + attachment.getFileid() + "&x=" + previewSize + "&y=" + previewSize
                 : getRemoteOrLocalUrl(accountUrl, cardRemoteId, attachment);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Attachment;
+import it.niedermann.nextcloud.deck.model.enums.EAttachmentType;
 import it.niedermann.nextcloud.deck.model.ocs.Version;
 
 /**
@@ -39,7 +40,9 @@ public class AttachmentUtil {
      * the {@link Attachment} itself will be returned instead.
      */
     public static String getThumbnailUrl(@NonNull Version version, @NonNull String accountUrl, @NonNull Long cardRemoteId, @NonNull Attachment attachment, @Px int previewSize) {
-        return version.supportsFileAttachments() && !TextUtils.isEmpty(String.valueOf(attachment.getFileId()))
+        return version.supportsFileAttachments() &&
+                EAttachmentType.FILE.equals(attachment.getType()) &&
+                !TextUtils.isEmpty(attachment.getFileId())
                 ? accountUrl + "/index.php/core/preview?fileId=" + attachment.getFileId() + "&x=" + previewSize + "&y=" + previewSize
                 : getRemoteOrLocalUrl(accountUrl, cardRemoteId, attachment);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/AttachmentUtil.java
@@ -42,8 +42,8 @@ public class AttachmentUtil {
     public static String getThumbnailUrl(@NonNull Version version, @NonNull String accountUrl, @NonNull Long cardRemoteId, @NonNull Attachment attachment, @Px int previewSize) {
         return version.supportsFileAttachments() &&
                 EAttachmentType.FILE.equals(attachment.getType()) &&
-                attachment.getFileid() != null
-                ? accountUrl + "/index.php/core/preview?fileId=" + attachment.getFileid() + "&x=" + previewSize + "&y=" + previewSize
+                attachment.getFileId() != null
+                ? accountUrl + "/index.php/core/preview?fileId=" + attachment.getFileId() + "&x=" + previewSize + "&y=" + previewSize
                 : getRemoteOrLocalUrl(accountUrl, cardRemoteId, attachment);
     }
 

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -205,7 +205,7 @@
     <string name="server_error">Chyba serveru</string>
     <string name="error_edit_activity_killed_by_android">Systém android ukončil režim úprav, protože potřeboval více systémových prostředků pro ostatní aplikace.</string>
 
-    <string name="error_dialog_title">Ó ne– co teď? 🙁</string>
+    <string name="error_dialog_title">Ó ne – co teď? 🙁</string>
     <string name="error_dialog_tip_token_mismatch_retry">Prosím pokuste se vynutit ukončení aplikace a spusťte ji znovu. Možná se něco nepodařilo při spojení s aplikací Nextcloud.</string>
     <string name="error_dialog_tip_clear_storage_might_help">Pokud problém přetrvává, zkuste problém vyřešit vyčištěním úložišť obou aplikací: Nextcloud a Nextcloud Deck.</string>
     <string name="error_dialog_tip_database_upgrade_failed">Přechod na novější verzi databáze se nezdařil. Prosíme nahlaste tento problém vývojářům a aby bylo možné aplikaci normálně používat, vyčistěte úložiště.</string>
@@ -217,7 +217,7 @@
     <string name="error_dialog_timeout_toggle">Zkontrolujte nastavení sítě. Někdy může pomoci vypnout a zase zapnout mobilní data nebo Wi-Fi.</string>
     <string name="error_dialog_check_server">Odpověď od serveru nebyla správná. Zkontrolujte, zda k aplikaci Deck můžete přistupovat přes webové rozhraní.</string>
     <string name="error_dialog_check_server_logs">Je problém s nastavením vámi využívané instance Nextcloud. Podívejte se do souborů se záznamem událostí na serveru.</string>
-    <string name="error_dialog_check_maintenance">Zkontrolujte, zda vámi využívaná instance Nextcloud právě není v tuto chvíli v režimu údržby.</string>
+    <string name="error_dialog_check_maintenance">Zkontrolujte, zda vámi využívaná instance Nextcloud není právě v tuto chvíli v režimu údržby.</string>
     <string name="error_dialog_insufficient_storage">Na vámi využívané instanci Nexcloud nezbývá žádné volné místo na úložišti. Aby bylo možné synchronizovat vaše místní změny do vámi využívaného cloudu, je třeba nejprve smazat nějaké soubory.</string>
     <string name="error_dialog_we_need_info">Abychom vám mohli pomoci, potřebujeme následující technické údaje:</string>
     <string name="error_dialog_redirect">Vámi využívaný server odpověděl HTTP stavovým kódem 302, což ukazuje na to, že na serveru buď není nainstalovaná aplikace Deck, nebo je něco nesprávně nastavené. Toto může být způsobeno uživatelsky určenými přepsáními v souboru .htaccess nebo Nextcloud aplikacemi jako je OID klient.</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -231,6 +231,9 @@
     <string name="info_box_maintenance_mode">Zerbitzaria mantentze-lanen moduan</string>
     <string name="info_box_version_not_supported">Zerbitzariaren %1$s bertsioa ez dago onartuta, mesedez eguneratu %2$s(e)ra</string>
     <string name="share_link">Partekatu esteka</string>
+    <string name="share_content">Partekatu edukia</string>
+    <string name="share_content_duedate">Epemuga:%1$s</string>
+    <string name="share_content_labels">Etiketak:%1$s</string>
     <string name="archive_cards">Artxibatu txartelak</string>
 
     <string name="manage_accounts">Kudeatu kontuak</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -231,6 +231,9 @@
     <string name="info_box_maintenance_mode">Servidor em modo de manutenção</string>
     <string name="info_box_version_not_supported">A versão %1$s do servidor não é suportada, atualize para %2$s</string>
     <string name="share_link">Link de compartilhamento</string>
+    <string name="share_content">Compartilhar conteúdo</string>
+    <string name="share_content_duedate">Data de Vencimento: %1$s</string>
+    <string name="share_content_labels">Etiquetas: %1$s</string>
     <string name="archive_cards">Cartões arquivados</string>
 
     <string name="manage_accounts">Gerenciar contas</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -236,6 +236,7 @@
     <string name="info_box_version_not_supported">Različica strežnika %1$s ni podprta. Priporočljiva je posodobitev na različico %2$s.</string>
     <string name="share_link">Povezava za souporabo</string>
     <string name="share_content_duedate">Datum preteka: %1$s</string>
+    <string name="share_content_labels">Oznake: %1$s</string>
     <string name="archive_cards">Arhiviraj naloge</string>
 
     <string name="manage_accounts">Upravljanje z računi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -233,6 +233,7 @@
     <string name="share_link">Bağlantıyı paylaş</string>
     <string name="share_content">İçeriği paylaş</string>
     <string name="share_content_duedate">Bitiş tarihi: %1$s</string>
+    <string name="share_content_labels">Etiketler: %1$s</string>
     <string name="archive_cards">Kartları arşivle</string>
 
     <string name="manage_accounts">Hesap yönetimi</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -199,12 +199,14 @@
     <string name="error_edit_activity_killed_by_android">Android 完成了編輯模式，因為它需要更多的系統資源來服務其他應用程式。</string>
 
     <string name="error_dialog_title">喔不 - 現在怎麼辦？🙁</string>
+    <string name="error_dialog_tip_token_mismatch_retry">請嘗試強制關閉該應用，然後重新啟動。 與 Nextcloud 應用的連接可能不正確。</string>
     <string name="error_dialog_tip_clear_storage_might_help">如果問題仍然存在，請嘗試清除兩個應用程序的存儲：Nextcloud 和 Nextcloud Deck 以解決此問題。</string>
     <string name="error_dialog_tip_database_upgrade_failed">數據庫升級失敗。 請報告問題，並清除存儲空間以正常使用該應用程序。</string>
     <string name="error_dialog_tip_clear_storage">您可以通過打開應用程式信息並選擇 存儲→清除存儲 來清除存儲。</string>
     <string name="error_dialog_tip_files_outdated">您的Nextcloud應用似乎已過時。請訪問 Play Store 或 F-Droid 以獲取最新版本。</string>
     <string name="error_dialog_tip_files_force_stop">您的 Nextcloud 應用程式似乎有問題。請嘗試強制停止 Nextcloud 應用程式和 Nextcloud Deck 應用程式。</string>
     <string name="error_dialog_tip_files_delete_storage">如果強行停止它們沒有幫助，則可以嘗試清除兩個應用程式的存儲。</string>
+    <string name="error_dialog_timeout_instance">在指定的時間內，您的伺服器沒有響應。 請確保您的 Nextcloud 運行良好。</string>
     <string name="error_dialog_timeout_toggle">檢查您的網絡連接。 有時候，切換流動數據或Wi-Fi可能會有所幫助。</string>
     <string name="error_dialog_check_server">您伺服器的回應不正確。請檢查您是否可以通過 web 界面存取看板應用程式。</string>
     <string name="error_dialog_check_server_logs">您的Nextcloud設置存在問題。 請查看伺服器記錄檔案。</string>
@@ -214,6 +216,10 @@
     <string name="error_dialog_redirect">您的伺服器以 HTTP 302 狀態代碼回應，這表示您尚未在伺服器上安裝 Deck 應用程式或配置錯誤。這可能是由於 .htaccess 檔案中的自定義替換或 Nextcloud 應用程式（如OID客戶端）引起的。</string>
     <string name="error_dialog_version_not_parsable">我們無法確定伺服器端 Deck 應用程式的版本。 請確保已安裝並啟用它。</string>
     <string name="error_dialog_account_might_not_be_authorized">您的Nextcloud應用程序賬戶可能不再被授權。</string>
+    <string name="error_dialog_user_not_found_in_database">當前用戶與我們數據庫中的用戶不匹配。 如果您在 Nextcloud 實例上使用 LDAP，則 Nextcloud應用程式可能已存儲了舊的用戶ID。</string>
+    <string name="error_dialog_capabilities_not_parsable">我們無法獲取您的伺服器功能。 請確保您的伺服器運行良好，並且其他客戶端應用程式能夠訪問Nextcloud。</string>
+    <string name="error_dialog_attachment_upload_failed">無法上傳附件。 請嘗試以其他方式共享它，並讓我們知道此錯誤。</string>
+    <string name="error_dialog_tip_disable_battery_optimizations">請禁用 Nextcloud 和 Deck 應用程式的所有電池優化。</string>
     <string name="error_action_open_deck_info">開啟 App 資訊</string>
     <string name="error_action_open_network">網路設定</string>
     <string name="error_action_server_logs">伺服器記錄</string>
@@ -224,6 +230,7 @@
     <string name="share_link">分享連結</string>
     <string name="share_content">分享內容</string>
     <string name="share_content_duedate">到期日：%1$s</string>
+    <string name="share_content_labels">標籤：%1$s</string>
     <string name="archive_cards">封存卡片</string>
 
     <string name="manage_accounts">賬戶管理</string>
@@ -237,6 +244,7 @@
     </plurals>
     <string name="simple_report">回報</string>
     <string name="error_action_open_battery_settings">電池設定</string>
+    <string name="move_warning">將卡片移至另一塊面板上時，註釋和附件均無法傳送。</string>
     <string name="clone_board">複製 board</string>
     <string name="cloning_board">正在複製 %1$s...</string>
     <string name="successfully_cloned_board">複製 %1$s 成功</string>
@@ -269,6 +277,7 @@
     <string name="simple_camera">相機</string>
     <string name="take_photo">拍照</string>
     <string name="take_photo_switch_camera">切換相機</string>
+    <string name="take_photo_toggle_torch">切換 torch</string>
     <string name="show_all_contacts">顯示所有聯絡人</string>
     <string name="show_all_files">顯示全部檔案</string>
     <string name="recent">最新</string>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -47,9 +47,6 @@
     <string name="shared_preference_last_account" translatable="false">it.niedermann.nextcloud.deck.last_account</string>
     <string name="shared_preference_last_board_for_account_" translatable="false">it.niedermann.nextcloud.deck.last_board_for_account_</string>
     <string name="shared_preference_last_stack_for_account_and_board_" translatable="false">it.niedermann.nextcloud.deck.last_stack_for_board_</string>
-    <integer name="minimum_server_app_major" translatable="false">0</integer>
-    <integer name="minimum_server_app_minor" translatable="false">6</integer>
-    <integer name="minimum_server_app_patch" translatable="false">4</integer>
 
     <!-- Transitions -->
     <string name="transition_attachment_preview" translatable="false">transition_attachment_preview_%1$s</string>

--- a/app/src/test/java/it/niedermann/nextcloud/deck/util/AttachmentUtilTest.java
+++ b/app/src/test/java/it/niedermann/nextcloud/deck/util/AttachmentUtilTest.java
@@ -8,6 +8,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import it.niedermann.nextcloud.deck.model.Attachment;
+import it.niedermann.nextcloud.deck.model.enums.EAttachmentType;
 import it.niedermann.nextcloud.deck.model.ocs.Version;
 
 import static org.junit.Assert.assertEquals;
@@ -22,21 +23,22 @@ public class AttachmentUtilTest {
         final Version versionThatDoesNotSupportFileAttachments = new Version("1.2.0", 1, 2, 0);
         final String accountUrl = "https://example.com";
 
-        // TODO depends on https://github.com/nextcloud/deck/pull/2638
-//        final Attachment attachment1 = new Attachment();
-//        attachment1.setFileId("1337");
-//        final String thumbnailUrl1 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, -1L, attachment1, 500);
-//        assertEquals("https://example.com/index.php/core/preview?fileId=1337&x=500&y=500", thumbnailUrl1);
-//
-//        final Attachment attachment2 = new Attachment();
-//        attachment2.setFileId("0815");
-//        final String thumbnailUrl2 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, 0L, attachment2, 4711);
-//        assertEquals("https://example.com/index.php/core/preview?fileId=0815&x=4711&y=4711", thumbnailUrl2);
+        final Attachment attachment1 = new Attachment();
+        attachment1.setFileid(1337L);
+        attachment1.setType(EAttachmentType.FILE);
+        final String thumbnailUrl1 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, -1L, attachment1, 500);
+        assertEquals("https://example.com/index.php/core/preview?fileId=1337&x=500&y=500", thumbnailUrl1);
+
+        final Attachment attachment2 = new Attachment();
+        attachment2.setFileid(815L);
+        attachment2.setType(EAttachmentType.FILE);
+        final String thumbnailUrl2 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, 0L, attachment2, 4711);
+        assertEquals("https://example.com/index.php/core/preview?fileId=815&x=4711&y=4711", thumbnailUrl2);
 
         // Given there is an invalid fileId...
         final Attachment attachment3 = new Attachment();
         attachment3.setId(999L);
-        attachment3.setFileid("");
+        attachment3.setFileid(null);
         final String thumbnailUrl3 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, 15L, attachment3, 205);
         // ... a fallback to the attachment itself should be returned
         assertEquals("https://example.com/index.php/apps/deck/cards/15/attachment/999", thumbnailUrl3);
@@ -44,7 +46,7 @@ public class AttachmentUtilTest {
         // Given the server version does not support file attachments yet...
         final Attachment attachment4 = new Attachment();
         attachment4.setId(111L);
-        attachment4.setFileid("222");
+        attachment4.setFileid(222L);
         final String thumbnailUrl4 = AttachmentUtil.getThumbnailUrl(versionThatDoesNotSupportFileAttachments, accountUrl, 333L, attachment4, 444);
         // ... a fallback to the attachment itself should be returned
         assertEquals("https://example.com/index.php/apps/deck/cards/333/attachment/111", thumbnailUrl4);

--- a/app/src/test/java/it/niedermann/nextcloud/deck/util/AttachmentUtilTest.java
+++ b/app/src/test/java/it/niedermann/nextcloud/deck/util/AttachmentUtilTest.java
@@ -36,7 +36,7 @@ public class AttachmentUtilTest {
         // Given there is an invalid fileId...
         final Attachment attachment3 = new Attachment();
         attachment3.setId(999L);
-        attachment3.setFileId("");
+        attachment3.setFileid("");
         final String thumbnailUrl3 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, 15L, attachment3, 205);
         // ... a fallback to the attachment itself should be returned
         assertEquals("https://example.com/index.php/apps/deck/cards/15/attachment/999", thumbnailUrl3);
@@ -44,7 +44,7 @@ public class AttachmentUtilTest {
         // Given the server version does not support file attachments yet...
         final Attachment attachment4 = new Attachment();
         attachment4.setId(111L);
-        attachment4.setFileId("222");
+        attachment4.setFileid("222");
         final String thumbnailUrl4 = AttachmentUtil.getThumbnailUrl(versionThatDoesNotSupportFileAttachments, accountUrl, 333L, attachment4, 444);
         // ... a fallback to the attachment itself should be returned
         assertEquals("https://example.com/index.php/apps/deck/cards/333/attachment/111", thumbnailUrl4);

--- a/app/src/test/java/it/niedermann/nextcloud/deck/util/AttachmentUtilTest.java
+++ b/app/src/test/java/it/niedermann/nextcloud/deck/util/AttachmentUtilTest.java
@@ -24,13 +24,13 @@ public class AttachmentUtilTest {
         final String accountUrl = "https://example.com";
 
         final Attachment attachment1 = new Attachment();
-        attachment1.setFileid(1337L);
+        attachment1.setFileId(1337L);
         attachment1.setType(EAttachmentType.FILE);
         final String thumbnailUrl1 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, -1L, attachment1, 500);
         assertEquals("https://example.com/index.php/core/preview?fileId=1337&x=500&y=500", thumbnailUrl1);
 
         final Attachment attachment2 = new Attachment();
-        attachment2.setFileid(815L);
+        attachment2.setFileId(815L);
         attachment2.setType(EAttachmentType.FILE);
         final String thumbnailUrl2 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, 0L, attachment2, 4711);
         assertEquals("https://example.com/index.php/core/preview?fileId=815&x=4711&y=4711", thumbnailUrl2);
@@ -38,7 +38,7 @@ public class AttachmentUtilTest {
         // Given there is an invalid fileId...
         final Attachment attachment3 = new Attachment();
         attachment3.setId(999L);
-        attachment3.setFileid(null);
+        attachment3.setFileId(null);
         final String thumbnailUrl3 = AttachmentUtil.getThumbnailUrl(versionThatDoesSupportFileAttachments, accountUrl, 15L, attachment3, 205);
         // ... a fallback to the attachment itself should be returned
         assertEquals("https://example.com/index.php/apps/deck/cards/15/attachment/999", thumbnailUrl3);
@@ -46,7 +46,7 @@ public class AttachmentUtilTest {
         // Given the server version does not support file attachments yet...
         final Attachment attachment4 = new Attachment();
         attachment4.setId(111L);
-        attachment4.setFileid(222L);
+        attachment4.setFileId(222L);
         final String thumbnailUrl4 = AttachmentUtil.getThumbnailUrl(versionThatDoesNotSupportFileAttachments, accountUrl, 333L, attachment4, 444);
         // ... a fallback to the attachment itself should be returned
         assertEquals("https://example.com/index.php/apps/deck/cards/333/attachment/111", thumbnailUrl4);


### PR DESCRIPTION
- [x] Detect server version `1.3.0` and use type `file` instead of `deck_file` when uploading new attachments
- [x] Detect server version `1.3.0` and use files API for generating preview thumbnails
- [x] Store new property `fileId` (comes only with server version `1.3.0`