### PR TITLE
Setting to disable eTags

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/DeckAPI.java
@@ -62,6 +62,9 @@ public interface DeckAPI {
     @GET("v1.0/boards")
     Observable<ParsedResponse<List<FullBoard>>> getBoards(@Query("details") boolean verbose, @Header(MODIFIED_SINCE_HEADER) String lastSync, @Header(IF_NONE_MATCH) String eTag);
 
+    @GET("v1.0/boards")
+    Observable<ParsedResponse<List<FullBoard>>> getBoards(@Query("details") boolean verbose, @Header(MODIFIED_SINCE_HEADER) String lastSync);
+
 
     // Stacks
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/ServerAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/ServerAdapter.java
@@ -129,9 +129,13 @@ public class ServerAdapter {
     }
 
     public void getBoards(IResponseCallback<ParsedResponse<List<FullBoard>>> responseCallback) {
-        RequestHelper.request(provider, () -> sharedPreferences.getBoolean(prefKeyEtags, true)
+        RequestHelper.request(provider, () -> isEtagsEnabled()
                 ? provider.getDeckAPI().getBoards(true, getLastSyncDateFormatted(responseCallback.getAccount().getId()), responseCallback.getAccount().getBoardsEtag())
                 : provider.getDeckAPI().getBoards(true, getLastSyncDateFormatted(responseCallback.getAccount().getId())), responseCallback);
+    }
+
+    public boolean isEtagsEnabled() {
+        return sharedPreferences.getBoolean(prefKeyEtags, true);
     }
 
     public void getCapabilities(String eTag, IResponseCallback<ParsedResponse<Capabilities>> responseCallback) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/SyncHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/SyncHelper.java
@@ -27,11 +27,14 @@ public class SyncHelper {
     private long accountId;
     private IResponseCallback<Boolean> responseCallback;
     private final Instant lastSync;
+    private final boolean etagsEnabled;
 
     public SyncHelper(ServerAdapter serverAdapter, DataBaseAdapter dataBaseAdapter, Instant lastSync) {
         this.serverAdapter = serverAdapter;
         this.dataBaseAdapter = dataBaseAdapter;
         this.lastSync = lastSync;
+        // check only once per sync
+        this.etagsEnabled = serverAdapter.isEtagsEnabled();
     }
 
     // Sync Server -> App
@@ -59,7 +62,7 @@ public class SyncHelper {
                                 DeckLog.warn("Conflicting changes on entity: " + existingEntity);
                                 // TODO: what to do?
                             } else {
-                                if (entityFromServer.getEtag() != null && entityFromServer.getEtag().equals(existingEntity.getEtag())) {
+                                if (etagsEnabled && entityFromServer.getEtag() != null &&  entityFromServer.getEtag().equals(existingEntity.getEtag())) {
                                     DeckLog.log("[" + provider.getClass().getSimpleName() + "] ETags do match! skipping " + existingEntity.getClass().getSimpleName() + " with localId: " + existingEntity.getLocalId());
                                     continue;
                                 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/providers/OcsProjectDataProvider.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/providers/OcsProjectDataProvider.java
@@ -33,6 +33,7 @@ public class OcsProjectDataProvider extends AbstractSyncDataProvider<OcsProject>
             public void onError(Throwable throwable) {
                 super.onError(throwable);
                 // dont break the sync!
+                // TODO i got here HTTP 404 once, maybe this should be considered?
                 DeckLog.logError(throwable);
                 responder.onResponse(Collections.emptyList());
             }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
@@ -24,6 +24,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     private BrandedSwitchPreference wifiOnlyPref;
     private BrandedSwitchPreference compactPref;
     private BrandedSwitchPreference debuggingPref;
+    private BrandedSwitchPreference eTagPref;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -75,6 +76,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         } else {
             DeckLog.error("Could not find preference with key: \"" + getString(R.string.pref_key_debugging) + "\"");
         }
+
+        eTagPref = findPreference(getString(R.string.pref_key_etags));
     }
 
     @Override
@@ -85,6 +88,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             wifiOnlyPref.applyBrand(mainColor);
             compactPref.applyBrand(mainColor);
             debuggingPref.applyBrand(mainColor);
+            eTagPref.applyBrand(mainColor);
         });
     }
 }

--- a/app/src/main/res/drawable/ic_baseline_speed_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_speed_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#757575"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20.38,8.57l-1.23,1.85a8,8 0,0 1,-0.22 7.58L5.07,18A8,8 0,0 1,15.58 6.85l1.85,-1.23A10,10 0,0 0,3.35 19a2,2 0,0 0,1.72 1h13.85a2,2 0,0 0,1.74 -1,10 10,0 0,0 -0.27,-10.44zM10.59,15.41a2,2 0,0 0,2.83 0l5.66,-8.49 -8.49,5.66a2,2 0,0 0,0 2.83z"/>
+</vector>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -10,6 +10,7 @@
     <string name="pref_key_compact" translatable="false">compact</string>
     <string name="pref_key_background_sync" translatable="false">backgroundSync</string>
     <string name="pref_key_debugging" translatable="false">debugging</string>
+    <string name="pref_key_etags" translatable="false">eTags</string>
 
     <string name="pref_value_background_sync_off">off</string>
     <string name="pref_value_background_15_minutes">15_minutes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,8 @@
     <string name="settings_branding_title">Branding</string>
     <string name="settings_compact_title">Compact mode</string>
     <string name="settings_debugging">Debug logs</string>
+    <string name="settings_etags">ETags</string>
+    <string name="settings_etags_summary">Speed up synchronization using ETags</string>
     <string name="settings_background_sync">Background synchronization</string>
     <string name="pref_value_wifi_and_mobile">Sync on Wi-Fi and mobile data</string>
     <string name="pref_value_wifi_only">Sync only on Wi-Fi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,8 +145,8 @@
     <string name="settings_branding_title">Branding</string>
     <string name="settings_compact_title">Compact mode</string>
     <string name="settings_debugging">Debug logs</string>
-    <string name="settings_etags">ETags</string>
-    <string name="settings_etags_summary">Speed up synchronization using ETags</string>
+    <string name="settings_etags">Use ETags</string>
+    <string name="settings_etags_summary">Speeds up synchronization</string>
     <string name="settings_background_sync">Background synchronization</string>
     <string name="pref_value_wifi_and_mobile">Sync on Wi-Fi and mobile data</string>
     <string name="pref_value_wifi_only">Sync only on Wi-Fi</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -42,5 +42,12 @@
             android:key="@string/pref_key_debugging"
             android:title="@string/settings_debugging"
             app:defaultValue="false" />
+
+        <it.niedermann.nextcloud.deck.ui.branding.BrandedSwitchPreference
+            android:icon="@drawable/ic_baseline_speed_24"
+            android:key="@string/pref_key_etags"
+            android:summary="@string/settings_etags_summary"
+            android:title="@string/settings_etags"
+            app:defaultValue="true" />
     </it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This issue is about introducing an expert setting to disable the  usage of ETags completely to force a full synchronization as a first aid in case of issues like https://github.com/nextcloud/deck/issues/2892 and https://github.com/nextcloud/deck/issues/2866

- [x] UI
- [x] Boards
- [x] Everything else seems to still use eTags. No idea why.