### PR TITLE
Simplify usage of ResponseCallback by pulling out an interface

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/IResponseCallback.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/IResponseCallback.java
@@ -1,44 +1,20 @@
 package it.niedermann.nextcloud.deck.api;
 
-import androidx.annotation.CallSuper;
-import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 import java.util.Collection;
 import java.util.List;
 
-import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.interfaces.AbstractRemoteEntity;
 
 
-public abstract class IResponseCallback<T> {
-    @Nullable
+public abstract class IResponseCallback<T> implements ResponseCallback<T> {
+    @NonNull
     protected Account account;
 
-    public IResponseCallback(@Nullable Account account) {
+    public IResponseCallback(@NonNull Account account) {
         this.account = account;
-    }
-
-    public abstract void onResponse(T response);
-
-    @CallSuper
-    public void onError(Throwable throwable) {
-        DeckLog.logError(throwable);
-    }
-
-    @CallSuper
-    public void onError(Throwable throwable, T locallyCreatedEntity) {
-        onError(throwable);
-    }
-
-    public static <T> IResponseCallback<T> getDefaultResponseCallback(Account account) {
-        return new IResponseCallback<T>(account) {
-            @Override
-            public void onResponse(T response) {
-                // Do Nothing
-            }
-
-        };
     }
 
     public void fillAccountIDs(T response) {
@@ -73,7 +49,7 @@ public abstract class IResponseCallback<T> {
         return false;
     }
 
-    @Nullable
+    @NonNull
     public Account getAccount() {
         return account;
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/ResponseCallback.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/ResponseCallback.java
@@ -1,0 +1,15 @@
+package it.niedermann.nextcloud.deck.api;
+
+import androidx.annotation.CallSuper;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+
+public interface ResponseCallback<T> {
+
+    void onResponse(T response);
+
+    @CallSuper
+    default void onError(Throwable throwable) {
+        DeckLog.logError(throwable);
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -37,6 +37,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.api.GsonConfig;
 import it.niedermann.nextcloud.deck.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.api.LastSyncUtil;
+import it.niedermann.nextcloud.deck.api.ResponseCallback;
 import it.niedermann.nextcloud.deck.exceptions.DeckException;
 import it.niedermann.nextcloud.deck.exceptions.OfflineException;
 import it.niedermann.nextcloud.deck.model.AccessControl;
@@ -564,12 +565,6 @@ public class SyncManager {
                     public void onResponse(FullBoard response) {
                         liveData.postValue(response);
                     }
-
-                    @SuppressLint("MissingSuperCall")
-                    @Override
-                    public void onError(Throwable throwable, FullBoard entity) {
-                        liveData.postError(throwable, entity);
-                    }
                 });
             }
         });
@@ -940,12 +935,6 @@ public class SyncManager {
                 @Override
                 public void onResponse(FullStack response) {
                     liveData.postValue(response);
-                }
-
-                @SuppressLint("MissingSuperCall")
-                @Override
-                public void onError(Throwable throwable, FullStack entity) {
-                    liveData.postError(throwable, entity);
                 }
             });
         });
@@ -1960,7 +1949,7 @@ public class SyncManager {
     // # filter widget
 
     @AnyThread
-    public void createFilterWidget(@NonNull FilterWidget filterWidget, @NonNull IResponseCallback<Integer> callback) {
+    public void createFilterWidget(@NonNull FilterWidget filterWidget, @NonNull ResponseCallback<Integer> callback) {
         doAsync(() -> {
             try {
                 int filterWidgetId = dataBaseAdapter.createFilterWidgetDirectly(filterWidget);
@@ -1984,7 +1973,7 @@ public class SyncManager {
     }
 
     @AnyThread
-    public void getFilterWidget(@NonNull Integer filterWidgetId, @NonNull IResponseCallback<FilterWidget> callback) {
+    public void getFilterWidget(@NonNull Integer filterWidgetId, @NonNull ResponseCallback<FilterWidget> callback) {
         doAsync(() -> {
             try {
                 callback.onResponse(dataBaseAdapter.getFilterWidgetByIdDirectly(filterWidgetId));
@@ -1995,7 +1984,7 @@ public class SyncManager {
     }
 
     @AnyThread
-    public void deleteFilterWidget(int filterWidgetId, @NonNull IResponseCallback<Boolean> callback) {
+    public void deleteFilterWidget(int filterWidgetId, @NonNull ResponseCallback<Boolean> callback) {
         doAsync(() -> {
             try {
                 dataBaseAdapter.deleteFilterWidgetDirectly(filterWidgetId);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/WrappedLiveData.java
@@ -1,10 +1,7 @@
 package it.niedermann.nextcloud.deck.persistence.sync.adapters.db.util;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.MutableLiveData;
-
-import it.niedermann.nextcloud.deck.DeckLog;
 
 /**
  * Extends a {@link MutableLiveData} with an error state
@@ -29,13 +26,7 @@ public class WrappedLiveData<T> extends MutableLiveData<T> {
     }
 
     public void postError(@Nullable Throwable error) {
-        postError(error, null);
-    }
-    public void postError(@Nullable Throwable error, @NonNull T locallyCreatedEntity) {
-        if (error == null) {
-            DeckLog.warn("Given error is null");
-        }
         setError(error);
-        postValue(locallyCreatedEntity);
+        postValue(null);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/DataPropagationHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/helpers/DataPropagationHelper.java
@@ -53,11 +53,11 @@ public class DataPropagationHelper {
                     @Override
                     public void onError(Throwable throwable) {
                         super.onError(throwable);
-                        new Thread(() -> callback.onError(throwable, entity)).start();
+                        new Thread(() -> callback.onError(throwable)).start();
                     }
                 }, entity);
             } catch (Throwable t) {
-                callback.onError(t, entity);
+                callback.onError(t);
             }
         } else {
             callback.onResponse(entity);
@@ -90,12 +90,12 @@ public class DataPropagationHelper {
                     public void onError(Throwable throwable) {
                         super.onError(throwable);
                         new Thread(() -> {
-                            callback.onError(throwable, entity);
+                            callback.onError(throwable);
                         }).start();
                     }
                 }, entity);
             } catch (Throwable t) {
-                callback.onError(t, entity);
+                callback.onError(t);
             }
         } else {
             callback.onResponse(entity);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentCreditsTab.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/about/AboutFragmentCreditsTab.java
@@ -55,7 +55,7 @@ public class AboutFragmentCreditsTab extends Fragment {
         binding.lastBackgroundSync.setText(
                 lastBackgroundSync == BACKGROUND_SYNC_NEVER_EXECUTED || settingsBackgroundSync.equals(backgroundSyncOffValue)
                         ? disabled(getString(R.string.simple_disabled), requireContext())
-                        : strong(DateUtil.getRelativeDateTimeString(getContext(), lastBackgroundSync))
+                        : strong(DateUtil.getRelativeDateTimeString(requireContext(), lastBackgroundSync))
         );
         binding.aboutMaintainer.setText(url(getString(R.string.about_maintainer), getString(R.string.url_maintainer)));
         binding.aboutMaintainer.setMovementMethod(new LinkMovementMethod());

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidget.java
@@ -9,7 +9,7 @@ import android.os.Bundle;
 
 import java.util.NoSuchElementException;
 
-import it.niedermann.nextcloud.deck.api.IResponseCallback;
+import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 
@@ -72,12 +72,7 @@ public class FilterWidget extends AppWidgetProvider {
         final SyncManager syncManager = new SyncManager(context);
 
         for (int appWidgetId : appWidgetIds) {
-            syncManager.deleteFilterWidget(appWidgetId, new IResponseCallback<Boolean>(null) {
-                @Override
-                public void onResponse(Boolean response) {
-
-                }
-            });
+            syncManager.deleteFilterWidget(appWidgetId, response -> DeckLog.verbose("Successfully deleted " + FilterWidget.class.getSimpleName() + " with id " + appWidgetId));
         }
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidgetConfigurationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidgetConfigurationActivity.java
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModelProvider;
 
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
-import it.niedermann.nextcloud.deck.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.databinding.ActivityFilterWidgetBinding;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 
@@ -51,12 +50,7 @@ public class FilterWidgetConfigurationActivity extends AppCompatActivity {
         binding.submit.setOnClickListener((v) -> {
             final Bundle extras = new Bundle();
 
-            viewModel.updateFilterWidget(new IResponseCallback<Integer>(null) {
-                @Override
-                public void onResponse(Integer response) {
-
-                }
-            });
+            viewModel.updateFilterWidget(response -> DeckLog.verbose("Successfully updated " + FilterWidget.class.getSimpleName() + " with id " + appWidgetId));
             Intent updateIntent = new Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE, null, getApplicationContext(), FilterWidget.class);
             extras.putInt(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidgetViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidgetViewModel.java
@@ -7,7 +7,7 @@ import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
-import it.niedermann.nextcloud.deck.api.IResponseCallback;
+import it.niedermann.nextcloud.deck.api.ResponseCallback;
 import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 
@@ -27,7 +27,7 @@ public class FilterWidgetViewModel extends AndroidViewModel {
         return this.config$;
     }
 
-    public void updateFilterWidget(@NonNull IResponseCallback<Integer> callback) {
+    public void updateFilterWidget(@NonNull ResponseCallback<Integer> callback) {
         syncManager.createFilterWidget(config$.getValue(), callback);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/stack/StackWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/stack/StackWidget.java
@@ -13,9 +13,7 @@ import androidx.annotation.ColorInt;
 
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
-import it.niedermann.nextcloud.deck.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.model.Stack;
-import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.MainActivity;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
@@ -57,12 +55,7 @@ public class StackWidget extends AppWidgetProvider {
 
         for (int appWidgetId : appWidgetIds) {
             DeckLog.info("Delete " + StackWidget.class.getSimpleName() + " with id " + appWidgetId);
-            syncManager.deleteFilterWidget(appWidgetId, new IResponseCallback<Boolean>(null) {
-                @Override
-                public void onResponse(Boolean response) {
-                    DeckLog.verbose("Successfully deleted " + StackWidget.class.getSimpleName() + " with id " + appWidgetId);
-                }
-            });
+            syncManager.deleteFilterWidget(appWidgetId, response -> DeckLog.verbose("Successfully deleted " + StackWidget.class.getSimpleName() + " with id " + appWidgetId));
         }
     }
 
@@ -89,17 +82,14 @@ public class StackWidget extends AppWidgetProvider {
                     views.setRemoteAdapter(R.id.stack_widget_lv, serviceIntent);
                     views.setEmptyView(R.id.stack_widget_lv, R.id.widget_stack_placeholder_iv);
 
-                    syncManager.getFilterWidget(appWidgetId, new IResponseCallback<FilterWidget>(null) {
-                        @Override
-                        public void onResponse(FilterWidget response) {
-                            final Stack stack = syncManager.getStackDirectly(response.getAccounts().get(0).getBoards().get(0).getStacks().get(0).getStackId());
-                            @ColorInt final Integer boardColor = syncManager.getBoardColorDirectly(response.getAccounts().get(0).getAccountId(), response.getAccounts().get(0).getBoards().get(0).getBoardId());
-                            views.setTextViewText(R.id.widget_stack_title_tv, stack.getTitle());
-                            views.setInt(R.id.widget_stack_header_icon, "setColorFilter", boardColor);
+                    syncManager.getFilterWidget(appWidgetId, response -> {
+                        final Stack stack = syncManager.getStackDirectly(response.getAccounts().get(0).getBoards().get(0).getStacks().get(0).getStackId());
+                        @ColorInt final Integer boardColor = syncManager.getBoardColorDirectly(response.getAccounts().get(0).getAccountId(), response.getAccounts().get(0).getBoards().get(0).getBoardId());
+                        views.setTextViewText(R.id.widget_stack_title_tv, stack.getTitle());
+                        views.setInt(R.id.widget_stack_header_icon, "setColorFilter", boardColor);
 
-                            awm.notifyAppWidgetViewDataChanged(appWidgetId, R.id.stack_widget_lv);
-                            awm.updateAppWidget(appWidgetId, views);
-                        }
+                        awm.notifyAppWidgetViewDataChanged(appWidgetId, R.id.stack_widget_lv);
+                        awm.updateAppWidget(appWidgetId, views);
                     });
                 } else {
                     DeckLog.warn("Does not yet exist");

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
-import it.niedermann.nextcloud.deck.api.IResponseCallback;
+import it.niedermann.nextcloud.deck.api.ResponseCallback;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.enums.ESortCriteria;
 import it.niedermann.nextcloud.deck.model.widget.filter.EWidgetType;
@@ -52,7 +52,7 @@ public class UpcomingWidget extends AppWidgetProvider {
                         fwa.setUsers(new FilterWidgetUser(syncManager.getUserByUidDirectly(account.getId(), account.getUserName()).getLocalId()));
                         return fwa;
                     }).collect(Collectors.toList()));
-                    syncManager.createFilterWidget(config, new IResponseCallback<Integer>(null) {
+                    syncManager.createFilterWidget(config, new ResponseCallback<Integer>() {
                         @Override
                         public void onResponse(Integer response) {
                             DeckLog.verbose("Successfully created " + UpcomingWidget.class.getSimpleName() + "with id " + appWidgetId);
@@ -62,7 +62,7 @@ public class UpcomingWidget extends AppWidgetProvider {
                         @Override
                         public void onError(Throwable throwable) {
                             DeckLog.error("Error while creating " + UpcomingWidget.class.getSimpleName() + "with id " + appWidgetId);
-                            super.onError(throwable);
+                            ResponseCallback.super.onError(throwable);
                             onDeleted(context, appWidgetIds);
                         }
                     });
@@ -96,12 +96,7 @@ public class UpcomingWidget extends AppWidgetProvider {
 
         for (int appWidgetId : appWidgetIds) {
             DeckLog.info("Delete " + UpcomingWidget.class.getSimpleName() + " with id " + appWidgetId);
-            syncManager.deleteFilterWidget(appWidgetId, new IResponseCallback<Boolean>(null) {
-                @Override
-                public void onResponse(Boolean response) {
-                    DeckLog.verbose("Successfully deleted " + UpcomingWidget.class.getSimpleName() + " with id " + appWidgetId);
-                }
-            });
+            syncManager.deleteFilterWidget(appWidgetId, response -> DeckLog.verbose("Successfully deleted " + UpcomingWidget.class.getSimpleName() + " with id " + appWidgetId));
         }
     }
 


### PR DESCRIPTION
- Makes an interface `ResponseCallback` which is not aware of any account
- Keep the `IResponseCallback` for scenarios where an account is relevant (and let it implement `ResponseCallback`)
- Mark `account` as `@NonNull` in `IResponseCallback` because this type now relies on an `account`
- Remove the `onError(Throwable t, Entity e)` methods: This can be the case when the entity was created successfully but the creation on server side failed. We do never use it, instead we display always an error. LiveData takes care of still displaying successfully created local entities. As a consequence the corresponding methods of `WrappedLiveData` are also removed

ToDo after merge (or when we have little branches): Rename `IResponseCallback` to `ResponseCallbackImpl` or so to match naming conventions.