### PR TITLE
Cover images

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/AbstractCardViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/AbstractCardViewHolder.java
@@ -121,7 +121,7 @@ public abstract class AbstractCardViewHolder extends RecyclerView.ViewHolder {
             final List<Attachment> coverImages = fullCard.getAttachments()
                     .stream()
                     .filter(attachment -> MimeTypeUtil.isImage(attachment.getMimetype()))
-                    .limit(coverImagesHolder.getResources().getInteger(R.integer.max_cover_images))
+                    .limit(maxCoverImagesCount)
                     .collect(Collectors.toList());
             if (coverImages.size() > 0) {
                 coverImagesHolder.setVisibility(View.VISIBLE);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/AbstractCardViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/AbstractCardViewHolder.java
@@ -5,7 +5,9 @@ import android.view.Menu;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
+import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.CallSuper;
@@ -17,20 +19,25 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
 import com.google.android.material.card.MaterialCardView;
 
 import org.jetbrains.annotations.Contract;
 
 import java.time.ZoneId;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.model.Attachment;
 import it.niedermann.nextcloud.deck.model.Card;
 import it.niedermann.nextcloud.deck.model.User;
 import it.niedermann.nextcloud.deck.model.enums.DBStatus;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
+import it.niedermann.nextcloud.deck.util.AttachmentUtil;
 import it.niedermann.nextcloud.deck.util.DateUtil;
+import it.niedermann.nextcloud.deck.util.MimeTypeUtil;
 import it.niedermann.nextcloud.deck.util.ViewUtil;
 
 public abstract class AbstractCardViewHolder extends RecyclerView.ViewHolder {
@@ -106,6 +113,38 @@ public abstract class AbstractCardViewHolder extends RecyclerView.ViewHolder {
         final Context context = cardDueDate.getContext();
         cardDueDate.setText(DateUtil.getRelativeDateTimeString(context, card.getDueDate().toEpochMilli()));
         ViewUtil.themeDueDate(context, cardDueDate, card.getDueDate().atZone(ZoneId.systemDefault()).toLocalDate());
+    }
+
+    protected static void setupCoverImages(@NonNull Account account, @NonNull ViewGroup coverImagesHolder, @NonNull FullCard fullCard, int maxCoverImagesCount) {
+        coverImagesHolder.removeAllViews();
+        if (maxCoverImagesCount > 0) {
+            final List<Attachment> coverImages = fullCard.getAttachments()
+                    .stream()
+                    .filter(attachment -> MimeTypeUtil.isImage(attachment.getMimetype()))
+                    .limit(coverImagesHolder.getResources().getInteger(R.integer.max_cover_images))
+                    .collect(Collectors.toList());
+            if (coverImages.size() > 0) {
+                coverImagesHolder.setVisibility(View.VISIBLE);
+                coverImagesHolder.post(() -> {
+                    for (Attachment coverImage : coverImages) {
+                        final ImageView coverImageView = new ImageView(coverImagesHolder.getContext());
+                        final int coverWidth = coverImagesHolder.getWidth() / coverImages.size();
+                        final int coverHeight = coverImagesHolder.getHeight();
+                        coverImageView.setLayoutParams(new LinearLayout.LayoutParams(coverWidth, coverHeight));
+                        coverImageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                        coverImagesHolder.addView(coverImageView);
+                        Glide.with(coverImageView)
+                                .load(AttachmentUtil.getThumbnailUrl(account, fullCard.getId(), coverImage, coverWidth, coverHeight))
+                                .placeholder(R.color.bg_info_box)
+                                .into(coverImageView);
+                    }
+                });
+            } else {
+                coverImagesHolder.setVisibility(View.GONE);
+            }
+        } else {
+            coverImagesHolder.setVisibility(View.GONE);
+        }
     }
 
     @Contract("null, _ -> false")

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
@@ -90,7 +90,7 @@ public class CardAdapter extends RecyclerView.Adapter<AbstractCardViewHolder> im
     @Override
     public AbstractCardViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int viewType) {
         if (viewType == R.layout.item_card_compact) {
-            return new CompactCardViewHolder(ItemCardCompactBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
+            return new CompactCardViewHolder(ItemCardCompactBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false), this.maxCoverImages);
         } else if (viewType == R.layout.item_card_default_only_title) {
             return new DefaultCardOnlyTitleViewHolder(ItemCardDefaultOnlyTitleBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
         }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CardAdapter.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentManager;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
@@ -62,6 +63,7 @@ public class CardAdapter extends RecyclerView.Adapter<AbstractCardViewHolder> im
     protected int mainColor;
     @StringRes
     private final int shareLinkRes;
+    protected final int maxCoverImages;
 
     public CardAdapter(@NonNull Activity activity, @NonNull FragmentManager fragmentManager, long stackId, @NonNull MainViewModel mainViewModel, @Nullable SelectCardListener selectCardListener) {
         this.activity = activity;
@@ -73,6 +75,9 @@ public class CardAdapter extends RecyclerView.Adapter<AbstractCardViewHolder> im
         this.selectCardListener = selectCardListener;
         this.mainColor = ContextCompat.getColor(this.activity, R.color.defaultBrand);
         this.compactMode = getDefaultSharedPreferences(this.activity).getBoolean(this.activity.getString(R.string.pref_key_compact), false);
+        this.maxCoverImages = PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(activity.getString(R.string.pref_key_cover_images), true)
+                ? activity.getResources().getInteger(R.integer.max_cover_images)
+                : 0;
         setHasStableIds(true);
     }
 
@@ -89,7 +94,7 @@ public class CardAdapter extends RecyclerView.Adapter<AbstractCardViewHolder> im
         } else if (viewType == R.layout.item_card_default_only_title) {
             return new DefaultCardOnlyTitleViewHolder(ItemCardDefaultOnlyTitleBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
         }
-        return new DefaultCardViewHolder(ItemCardDefaultBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
+        return new DefaultCardViewHolder(ItemCardDefaultBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false), this.maxCoverImages);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CompactCardViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CompactCardViewHolder.java
@@ -38,7 +38,7 @@ public class CompactCardViewHolder extends AbstractCardViewHolder {
     public void bind(@NonNull FullCard fullCard, @NonNull Account account, @Nullable Long boardRemoteId, boolean hasEditPermission, @MenuRes int optionsMenu, @NonNull CardOptionsItemSelectedListener optionsItemsSelectedListener, @NonNull String counterMaxValue, @ColorInt int mainColor) {
         super.bind(fullCard, account, boardRemoteId, hasEditPermission, optionsMenu, optionsItemsSelectedListener, counterMaxValue, mainColor);
 
-        setupCoverImages(account, binding.coverImages, fullCard, maxCoverImagesCount);
+        setupCoverImages(account, binding.coverImages, fullCard, Math.min(maxCoverImagesCount, 1));
 
         final List<Label> labels = fullCard.getLabels();
         if (labels != null && labels.size() > 0) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CompactCardViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CompactCardViewHolder.java
@@ -32,6 +32,7 @@ public class CompactCardViewHolder extends AbstractCardViewHolder {
     /**
      * Removes all {@link OnClickListener} and {@link OnLongClickListener}
      */
+    @Override
     public void bind(@NonNull FullCard fullCard, @NonNull Account account, @Nullable Long boardRemoteId, boolean hasEditPermission, @MenuRes int optionsMenu, @NonNull CardOptionsItemSelectedListener optionsItemsSelectedListener, @NonNull String counterMaxValue, @ColorInt int mainColor) {
         super.bind(fullCard, account, boardRemoteId, hasEditPermission, optionsMenu, optionsItemsSelectedListener, counterMaxValue, mainColor);
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CompactCardViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/CompactCardViewHolder.java
@@ -22,11 +22,13 @@ import it.niedermann.nextcloud.deck.model.full.FullCard;
 
 public class CompactCardViewHolder extends AbstractCardViewHolder {
     private final ItemCardCompactBinding binding;
+    private final int maxCoverImagesCount;
 
     @SuppressWarnings("WeakerAccess")
-    public CompactCardViewHolder(@NonNull ItemCardCompactBinding binding) {
+    public CompactCardViewHolder(@NonNull ItemCardCompactBinding binding, int maxCoverImagesCount) {
         super(binding.getRoot());
         this.binding = binding;
+        this.maxCoverImagesCount = maxCoverImagesCount;
     }
 
     /**
@@ -36,7 +38,9 @@ public class CompactCardViewHolder extends AbstractCardViewHolder {
     public void bind(@NonNull FullCard fullCard, @NonNull Account account, @Nullable Long boardRemoteId, boolean hasEditPermission, @MenuRes int optionsMenu, @NonNull CardOptionsItemSelectedListener optionsItemsSelectedListener, @NonNull String counterMaxValue, @ColorInt int mainColor) {
         super.bind(fullCard, account, boardRemoteId, hasEditPermission, optionsMenu, optionsItemsSelectedListener, counterMaxValue, mainColor);
 
-        List<Label> labels = fullCard.getLabels();
+        setupCoverImages(account, binding.coverImages, fullCard, maxCoverImagesCount);
+
+        final List<Label> labels = fullCard.getLabels();
         if (labels != null && labels.size() > 0) {
             binding.labels.updateLabels(labels);
             binding.labels.setVisibility(View.VISIBLE);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/DefaultCardViewHolder.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/DefaultCardViewHolder.java
@@ -6,7 +6,6 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
@@ -15,24 +14,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
-import com.bumptech.glide.Glide;
 import com.google.android.material.card.MaterialCardView;
 
 import org.jetbrains.annotations.Contract;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.databinding.ItemCardDefaultBinding;
 import it.niedermann.nextcloud.deck.model.Account;
-import it.niedermann.nextcloud.deck.model.Attachment;
 import it.niedermann.nextcloud.deck.model.Card.TaskStatus;
 import it.niedermann.nextcloud.deck.model.Label;
 import it.niedermann.nextcloud.deck.model.User;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
-import it.niedermann.nextcloud.deck.util.AttachmentUtil;
-import it.niedermann.nextcloud.deck.util.MimeTypeUtil;
 
 public class DefaultCardViewHolder extends AbstractCardViewHolder {
     private final ItemCardDefaultBinding binding;
@@ -61,35 +55,7 @@ public class DefaultCardViewHolder extends AbstractCardViewHolder {
             binding.overlappingAvatars.setVisibility(View.GONE);
         }
 
-        binding.coverImages.removeAllViews();
-        if (maxCoverImagesCount > 0) {
-            final List<Attachment> coverImages = fullCard.getAttachments()
-                    .stream()
-                    .filter(attachment -> MimeTypeUtil.isImage(attachment.getMimetype()))
-                    .limit(context.getResources().getInteger(R.integer.max_cover_images))
-                    .collect(Collectors.toList());
-            if (coverImages.size() > 0) {
-                binding.coverImages.setVisibility(View.VISIBLE);
-                binding.coverImages.post(() -> {
-                    for (Attachment coverImage : coverImages) {
-                        final ImageView coverImageView = new ImageView(binding.coverImages.getContext());
-                        final int coverWidth = binding.coverImages.getWidth() / coverImages.size();
-                        final int coverHeight = binding.coverImages.getHeight();
-                        coverImageView.setLayoutParams(new LinearLayout.LayoutParams(coverWidth, coverHeight));
-                        coverImageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
-                        binding.coverImages.addView(coverImageView);
-                        Glide.with(coverImageView)
-                                .load(AttachmentUtil.getThumbnailUrl(account, fullCard.getId(), coverImage, coverWidth, coverHeight))
-                                .placeholder(R.color.bg_info_box)
-                                .into(coverImageView);
-                    }
-                });
-            } else {
-                binding.coverImages.setVisibility(View.GONE);
-            }
-        } else {
-            binding.coverImages.setVisibility(View.GONE);
-        }
+        setupCoverImages(account, binding.coverImages, fullCard, maxCoverImagesCount);
 
         final int attachmentsCount = fullCard.getAttachments().size();
         if (attachmentsCount == 0) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
@@ -23,6 +23,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
     private BrandedSwitchPreference wifiOnlyPref;
     private BrandedSwitchPreference compactPref;
+    private BrandedSwitchPreference coverImagesPref;
     private BrandedSwitchPreference compressImageAttachmentsPref;
     private BrandedSwitchPreference debuggingPref;
     private BrandedSwitchPreference eTagPref;
@@ -32,48 +33,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         setPreferencesFromResource(R.xml.settings, rootKey);
 
         wifiOnlyPref = findPreference(getString(R.string.pref_key_wifi_only));
-        if (wifiOnlyPref != null) {
-            wifiOnlyPref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
-                final Boolean syncOnWifiOnly = (Boolean) newValue;
-                DeckLog.log("syncOnWifiOnly:", syncOnWifiOnly);
-                return true;
-            });
-        } else {
-            DeckLog.error("Could not find preference with key: ", getString(R.string.pref_key_wifi_only));
-        }
-
-        Preference themePref = findPreference(getString(R.string.pref_key_dark_theme));
-        if (themePref != null) {
-            themePref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
-                setAppTheme(Integer.parseInt((String) newValue));
-                requireActivity().setResult(Activity.RESULT_OK);
-                ActivityCompat.recreate(requireActivity());
-                return true;
-            });
-        } else {
-            DeckLog.error("Could not find preference with key:", getString(R.string.pref_key_dark_theme));
-        }
-
-        compressImageAttachmentsPref = findPreference(getString(R.string.pref_key_compress_image_attachments));
-        if (compressImageAttachmentsPref != null) {
-            compressImageAttachmentsPref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
-                DeckLog.log("compress image attachments:", newValue);
-                return true;
-            });
-        } else {
-            DeckLog.error("Could not find preference with key:", getString(R.string.pref_key_compress_image_attachments));
-        }
-
+        coverImagesPref = findPreference(getString(R.string.pref_key_cover_images));
         compactPref = findPreference(getString(R.string.pref_key_compact));
-        final ListPreference backgroundSyncPref = findPreference(getString(R.string.pref_key_background_sync));
-        if (backgroundSyncPref != null) {
-            backgroundSyncPref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
-                SyncWorker.update(requireContext().getApplicationContext(), (String) newValue);
-                return true;
-            });
-        } else {
-            DeckLog.error("Could not find preference with key", getString(R.string.pref_key_background_sync));
-        }
+        compressImageAttachmentsPref = findPreference(getString(R.string.pref_key_compress_image_attachments));
+        eTagPref = findPreference(getString(R.string.pref_key_etags));
 
         debuggingPref = findPreference(getString(R.string.pref_key_debugging));
         if (debuggingPref != null) {
@@ -86,7 +49,27 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             DeckLog.error("Could not find preference with key:", getString(R.string.pref_key_debugging));
         }
 
-        eTagPref = findPreference(getString(R.string.pref_key_etags));
+        final ListPreference backgroundSyncPref = findPreference(getString(R.string.pref_key_background_sync));
+        if (backgroundSyncPref != null) {
+            backgroundSyncPref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                SyncWorker.update(requireContext().getApplicationContext(), (String) newValue);
+                return true;
+            });
+        } else {
+            DeckLog.error("Could not find preference with key", getString(R.string.pref_key_background_sync));
+        }
+
+        final Preference themePref = findPreference(getString(R.string.pref_key_dark_theme));
+        if (themePref != null) {
+            themePref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                setAppTheme(Integer.parseInt((String) newValue));
+                requireActivity().setResult(Activity.RESULT_OK);
+                ActivityCompat.recreate(requireActivity());
+                return true;
+            });
+        } else {
+            DeckLog.error("Could not find preference with key:", getString(R.string.pref_key_dark_theme));
+        }
     }
 
     @Override
@@ -96,6 +79,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         DeckApplication.readCurrentAccountColor().observe(getViewLifecycleOwner(), (mainColor) -> {
             wifiOnlyPref.applyBrand(mainColor);
             compactPref.applyBrand(mainColor);
+            coverImagesPref.applyBrand(mainColor);
             compressImageAttachmentsPref.applyBrand(mainColor);
             debuggingPref.applyBrand(mainColor);
             eTagPref.applyBrand(mainColor);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsAdapter.java
@@ -98,7 +98,7 @@ public class UpcomingCardsAdapter extends RecyclerView.Adapter<RecyclerView.View
         if (viewType == R.layout.item_section) {
             return new UpcomingCardsSectionViewHolder(ItemSectionBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
         } else if (viewType == R.layout.item_card_compact) {
-            return new CompactCardViewHolder(ItemCardCompactBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
+            return new CompactCardViewHolder(ItemCardCompactBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false), this.maxCoverImages);
         } else if (viewType == R.layout.item_card_default_only_title) {
             return new DefaultCardOnlyTitleViewHolder(ItemCardDefaultOnlyTitleBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
         }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsAdapter.java
@@ -8,6 +8,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentManager;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ public class UpcomingCardsAdapter extends RecyclerView.Adapter<RecyclerView.View
     private final Consumer<FullCard> archiveCard;
     @NonNull
     private final Consumer<Card> deleteCard;
+    private final int maxCoverImages;
 
     public UpcomingCardsAdapter(@NonNull Activity activity, @NonNull FragmentManager fragmentManager,
                                 @NonNull BiConsumer<Account, Card> assignCard,
@@ -68,6 +70,9 @@ public class UpcomingCardsAdapter extends RecyclerView.Adapter<RecyclerView.View
         this.unassignCard = unassignCard;
         this.archiveCard = archiveCard;
         this.deleteCard = deleteCard;
+        this.maxCoverImages = PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(activity.getString(R.string.pref_key_cover_images), true)
+                ? activity.getResources().getInteger(R.integer.max_cover_images)
+                : 0;
         setHasStableIds(true);
     }
 
@@ -97,7 +102,7 @@ public class UpcomingCardsAdapter extends RecyclerView.Adapter<RecyclerView.View
         } else if (viewType == R.layout.item_card_default_only_title) {
             return new DefaultCardOnlyTitleViewHolder(ItemCardDefaultOnlyTitleBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
         }
-        return new DefaultCardViewHolder(ItemCardDefaultBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false));
+        return new DefaultCardViewHolder(ItemCardDefaultBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false), this.maxCoverImages);
     }
 
     @Override
@@ -135,7 +140,8 @@ public class UpcomingCardsAdapter extends RecyclerView.Adapter<RecyclerView.View
                 throw new IllegalStateException("Item at position " + position + " is a " + item.getClass().getSimpleName() + " but viewHolder is no " + UpcomingCardsSectionViewHolder.class.getSimpleName());
             }
         } else if (item.getClass() == UpcomingCardsAdapterItem.class || item instanceof UpcomingCardsAdapterItem) {
-            if (viewHolder.getClass() == AbstractCardViewHolder.class || viewHolder instanceof AbstractCardViewHolder) {
+            viewHolder.getClass();
+            if (viewHolder instanceof AbstractCardViewHolder) {
                 final UpcomingCardsAdapterItem cardItem = (UpcomingCardsAdapterItem) item;
                 AbstractCardViewHolder cardViewHolder = ((AbstractCardViewHolder) viewHolder);
                 cardViewHolder.bind(cardItem.getFullCard(), cardItem.getAccount(), cardItem.getCurrentBoardRemoteId(), cardItem.currentBoardHasEditPermission(), R.menu.card_menu,

--- a/app/src/main/res/layout/item_card_compact.xml
+++ b/app/src/main/res/layout/item_card_compact.xml
@@ -17,8 +17,19 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingTop="@dimen/spacer_1x"
         android:paddingBottom="@dimen/spacer_1x">
+
+        <LinearLayout
+            android:id="@+id/coverImages"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1"
+            android:layout_marginBottom="@dimen/spacer_1x"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:background="@color/bg_info_box"
+            tools:visibility="visible" />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_card_compact.xml
+++ b/app/src/main/res/layout/item_card_compact.xml
@@ -10,98 +10,98 @@
     android:layout_marginEnd="@dimen/spacer_2x"
     android:layout_marginBottom="@dimen/spacer_1x"
     android:focusable="true"
-    app:cardElevation="@dimen/spacer_1qx"
-    app:cardBackgroundColor="@color/bg_card">
+    app:cardBackgroundColor="@color/bg_card"
+    app:cardElevation="@dimen/spacer_1qx">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/spacer_1x">
+        android:layout_height="wrap_content">
 
-        <LinearLayout
+        <FrameLayout
             android:id="@+id/coverImages"
-            android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:layout_rowWeight="1"
-            android:layout_columnWeight="1"
-            android:layout_marginBottom="@dimen/spacer_1x"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            tools:background="@color/bg_info_box"
-            tools:visibility="visible" />
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            tools:background="@color/bg_info_box" />
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingStart="@dimen/spacer_2x"
-            android:paddingEnd="@dimen/spacer_1x">
-
-            <TextView
-                android:id="@+id/card_title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4sp"
-                android:layout_weight="1"
-                android:textColor="?attr/colorAccent"
-                android:textSize="18sp"
-                tools:ignore="RtlSymmetry"
-                tools:text="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut l" />
-
-            <ImageView
-                android:id="@+id/not_synced_yet"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8sp"
-                android:contentDescription="@string/not_synced_yet"
-                android:visibility="gone"
-                app:srcCompat="@drawable/ic_sync_blue_24dp"
-                tools:visibility="visible" />
+            android:orientation="vertical"
+            android:paddingTop="@dimen/spacer_1x"
+            android:paddingBottom="@dimen/spacer_1x">
 
             <LinearLayout
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:paddingStart="@dimen/spacer_1hx"
-                tools:ignore="RtlSymmetry">
+                android:paddingStart="@dimen/spacer_2x"
+                android:paddingEnd="@dimen/spacer_1x">
 
-                <androidx.appcompat.widget.AppCompatTextView
-                    android:id="@+id/card_due_date"
+                <TextView
+                    android:id="@+id/card_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4sp"
+                    android:layout_weight="1"
+                    android:textColor="?attr/colorAccent"
+                    android:textSize="18sp"
+                    tools:ignore="RtlSymmetry"
+                    tools:text="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut l" />
+
+                <ImageView
+                    android:id="@+id/not_synced_yet"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:background="@drawable/due_tomorrow_background"
-                    android:drawablePadding="@dimen/spacer_1hx"
-                    android:gravity="center"
-                    android:padding="@dimen/spacer_1hx"
-                    android:paddingEnd="@dimen/spacer_1x"
-                    android:textColor="@color/fg_secondary"
-                    app:drawableStartCompat="@drawable/calendar_blank_grey600_24dp"
-                    tools:text="tomorrow" />
+                    android:layout_marginTop="8sp"
+                    android:contentDescription="@string/not_synced_yet"
+                    android:visibility="gone"
+                    app:srcCompat="@drawable/ic_sync_blue_24dp"
+                    tools:visibility="visible" />
 
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingStart="@dimen/spacer_1hx"
+                    tools:ignore="RtlSymmetry">
+
+                    <androidx.appcompat.widget.AppCompatTextView
+                        android:id="@+id/card_due_date"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/due_tomorrow_background"
+                        android:drawablePadding="@dimen/spacer_1hx"
+                        android:gravity="center"
+                        android:padding="@dimen/spacer_1hx"
+                        android:paddingEnd="@dimen/spacer_1x"
+                        android:textColor="@color/fg_secondary"
+                        app:drawableStartCompat="@drawable/calendar_blank_grey600_24dp"
+                        tools:text="tomorrow" />
+
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/card_menu"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/label_menu"
+                    android:padding="@dimen/spacer_1hx"
+                    android:tint="?attr/colorAccent"
+                    app:srcCompat="@drawable/ic_menu" />
             </LinearLayout>
 
-            <ImageView
-                android:id="@+id/card_menu"
-                android:layout_width="wrap_content"
+            <it.niedermann.nextcloud.deck.ui.view.labellayout.CompactLabelLayout
+                android:id="@+id/labels"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/label_menu"
-                android:padding="@dimen/spacer_1hx"
-                android:tint="?attr/colorAccent"
-                app:srcCompat="@drawable/ic_menu" />
+                android:layout_marginTop="@dimen/spacer_1x"
+                android:animateLayoutChanges="true"
+                android:paddingStart="@dimen/spacer_2x"
+                android:paddingEnd="@dimen/spacer_2x"
+                app:flexWrap="nowrap"
+                tools:layout_height="@dimen/avatar_size" />
+
         </LinearLayout>
-
-        <it.niedermann.nextcloud.deck.ui.view.labellayout.CompactLabelLayout
-            android:id="@+id/labels"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/spacer_1x"
-            android:animateLayoutChanges="true"
-            android:paddingStart="@dimen/spacer_2x"
-            android:paddingEnd="@dimen/spacer_2x"
-            app:flexWrap="nowrap"
-            tools:layout_height="@dimen/avatar_size" />
-
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_card_default.xml
+++ b/app/src/main/res/layout/item_card_default.xml
@@ -10,21 +10,33 @@
     android:layout_marginEnd="@dimen/spacer_2x"
     android:layout_marginBottom="@dimen/spacer_1x"
     android:focusable="true"
-    app:cardElevation="@dimen/spacer_1qx"
-    app:cardBackgroundColor="@color/bg_card">
+    app:cardBackgroundColor="@color/bg_card"
+    app:cardElevation="@dimen/spacer_1qx">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingTop="@dimen/spacer_1x"
         android:paddingBottom="@dimen/spacer_1x">
+
+        <GridLayout
+            android:id="@+id/coverImages"
+            android:layout_width="match_parent"
+            android:layout_height="130dp"
+            android:layout_marginBottom="@dimen/spacer_1x"
+            android:columnCount="3"
+            android:rowCount="1"
+            android:visibility="gone"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
+            tools:visibility="visible" />
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:paddingStart="@dimen/spacer_2x"
+            android:paddingTop="@dimen/spacer_1x"
             android:paddingEnd="@dimen/spacer_2x">
 
             <TextView

--- a/app/src/main/res/layout/item_card_default.xml
+++ b/app/src/main/res/layout/item_card_default.xml
@@ -19,16 +19,16 @@
         android:orientation="vertical"
         android:paddingBottom="@dimen/spacer_1x">
 
-        <GridLayout
+        <LinearLayout
             android:id="@+id/coverImages"
             android:layout_width="match_parent"
             android:layout_height="130dp"
-            android:layout_marginBottom="@dimen/spacer_1x"
-            android:columnCount="3"
-            android:rowCount="1"
-            android:visibility="gone"
-            android:layout_columnWeight="1"
             android:layout_rowWeight="1"
+            android:layout_columnWeight="1"
+            android:layout_marginBottom="@dimen/spacer_1x"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:background="@color/bg_info_box"
             tools:visibility="visible" />
 
         <LinearLayout

--- a/app/src/main/res/layout/item_card_default_only_title.xml
+++ b/app/src/main/res/layout/item_card_default_only_title.xml
@@ -12,7 +12,17 @@
     android:focusable="true"
     app:cardElevation="@dimen/spacer_1qx"
     app:cardBackgroundColor="@color/bg_card">
-
+    
+    <LinearLayout
+        android:id="@+id/coverImages"
+        android:layout_width="match_parent"
+        android:layout_height="130dp"
+        android:layout_rowWeight="1"
+        android:layout_columnWeight="1"
+        android:layout_marginBottom="@dimen/spacer_1x"
+        android:orientation="horizontal"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/customization.xml
+++ b/app/src/main/res/values/customization.xml
@@ -10,4 +10,6 @@
     <integer name="comment_max_length">1000</integer>
     <!-- Parent comment line counter -->
     <integer name="comment_parent_max_lines">3</integer>
+    <!-- Maximum cover images per card -->
+    <integer name="max_cover_images">3</integer>
 </resources>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -8,6 +8,7 @@
     <string name="pref_key_wifi_only" translatable="false">wifiOnly</string>
     <string name="pref_key_dark_theme" translatable="false">darkTheme</string>
     <string name="pref_key_compact" translatable="false">compact</string>
+    <string name="pref_key_cover_images" translatable="false">cover_images</string>
     <string name="pref_key_compress_image_attachments" translatable="false">compressImageAttachments</string>
     <string name="pref_key_background_sync" translatable="false">backgroundSync</string>
     <string name="pref_key_debugging" translatable="false">debugging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="settings_theme_title">Theme</string>
     <string name="settings_branding_title">Branding</string>
     <string name="settings_compact_title">Compact mode</string>
+    <string name="settings_cover_images_title">Cover images</string>
+    <string name="settings_cover_images_summary">Attachments uploaded with Deck ≥ 1.3.0</string>
     <string name="settings_debugging">Debug logs</string>
     <string name="settings_etags">Use ETags</string>
     <string name="settings_etags_summary">Speeds up synchronization</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,7 +145,6 @@
     <string name="settings_branding_title">Branding</string>
     <string name="settings_compact_title">Compact mode</string>
     <string name="settings_cover_images_title">Cover images</string>
-    <string name="settings_cover_images_summary">Attachments uploaded with Deck ≥ 1.3.0</string>
     <string name="settings_debugging">Debug logs</string>
     <string name="settings_etags">Use ETags</string>
     <string name="settings_etags_summary">Speeds up synchronization</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -20,8 +20,8 @@
         <it.niedermann.nextcloud.deck.ui.branding.BrandedSwitchPreference
             android:icon="@drawable/ic_baseline_photo_size_select_small_24"
             android:key="@string/pref_key_compress_image_attachments"
-            android:title="@string/settings_compress_image_attachments"
             android:summary="@string/settings_compress_image_attachments_summary"
+            android:title="@string/settings_compress_image_attachments"
             app:defaultValue="true" />
     </it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory>
 
@@ -40,6 +40,13 @@
             android:key="@string/pref_key_compact"
             android:title="@string/settings_compact_title"
             app:defaultValue="false" />
+
+        <it.niedermann.nextcloud.deck.ui.branding.BrandedSwitchPreference
+            android:icon="@drawable/ic_image_grey600_24dp"
+            android:key="@string/pref_key_cover_images"
+            android:summary="@string/settings_cover_images_summary"
+            android:title="@string/settings_cover_images_title"
+            app:defaultValue="true" />
     </it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory>
 
     <it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory android:title="@string/simple_expert_settings">

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -44,7 +44,6 @@
         <it.niedermann.nextcloud.deck.ui.branding.BrandedSwitchPreference
             android:icon="@drawable/ic_image_grey600_24dp"
             android:key="@string/pref_key_cover_images"
-            android:summary="@string/settings_cover_images_summary"
             android:title="@string/settings_cover_images_title"
             app:defaultValue="true" />
     </it.niedermann.nextcloud.deck.ui.branding.BrandedPreferenceCategory>


### PR DESCRIPTION
Pendant to https://github.com/nextcloud/deck/pull/2858

Shows up to 3 cover images on one card (from the attachments). Can be switched off in the settings because it can consume lots of mobile traffic, especially for attachments uploaded with server versions `1.2.0` and below and i don't know how the performance behaves on weak devices...

![grafik](https://user-images.githubusercontent.com/4741199/115141043-95ff0e80-a03a-11eb-88b0-bf34f0880edc.png)
