### PR TITLE
fix #344 and #345 comments recyclerview layout problems with adjacent layouts

### DIFF
--- a/app/src/main/res/layout/fragment_card_edit_tab_comments.xml
+++ b/app/src/main/res/layout/fragment_card_edit_tab_comments.xml
@@ -10,6 +10,7 @@
         android:id="@+id/comments"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:scrollbars="vertical"
         android:layout_above="@id/addCommentLayout"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:reverseLayout="true"

--- a/app/src/main/res/layout/fragment_card_edit_tab_comments.xml
+++ b/app/src/main/res/layout/fragment_card_edit_tab_comments.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/comments"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_above="@id/addCommentLayout"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:reverseLayout="true"


### PR DESCRIPTION
The comments recyclerview layout was not behaving well with adjacent layouts, for example it was scrolling upwards everytime the keyboard opened.

With this request it recognizes the keyboard and the "add-comments layouts" at the bottom correctly.

I also added the missing scrollbar.