### PR TITLE
Fix: "Add to Card" activity is now visible in the share dialog

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
             android:name=".ui.sharetarget.ShareTargetActivity"
             android:label="@string/share_add_to_card"
             android:theme="@style/SplashTheme"
-            android:exported="false">
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
At some point the app stopped showing in Android's share menu dialog.

It seems to have stopped working because the "exported" flag was set to false, this PR has a very simple commit that sets said flag to true.