### PR TITLE
[Fix] "FilesUtil" Temporary cache creation now double checks

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/FilesUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/FilesUtil.java
@@ -66,8 +66,7 @@ public class FilesUtil {
             // In order to mitigate this issue, we wait some time and recheck.
             // It only happens when creating the cache folder of a given board/card for the first time.
 
-            boolean makeDir = tempDir.mkdirs();
-            if (makeDir) {
+            if (tempDir.mkdirs()) {
                 DeckLog.verbose("--- Creation successful (1st Attempt)");
             } else if (!tempDir.exists()) {
                 // Wait a 0.5 seconds, just in case another thread created said folder


### PR DESCRIPTION
As it currently stands, when uploading multiple files at once (using the share dialog) an `IOException` is triggered.
The exception is thrown because the function that creates the temporary cache directory for the upload overlaps with itself (as we are uploading many files asynchronously).

<img width="276" alt="mpv_scxCor9Gxi" src="https://user-images.githubusercontent.com/1771953/147896411-11562f1d-91f0-4e10-9134-9db2d2ed8e1c.png">

The exception given is: `IOException: Directory for temporary file does not exist and could not be created`


This PR mitigates the error by double checking the folder's existence. Then, if needed, waiting 500ms and trying again to create the folder.

This may also fix the exception `IOException: Could not delete local file after successful upload`.
I do not know for sure, but that exception was what started my investigation into fixing multi-file uploads and has since worked for me in the emulator after fixing the previous exception.

**Steps to reproduce:**
1. Clear Deck's Storage & Cache from Android's application settings
2. Open Deck
3. Login to your Nextcloud account
4. Create a new board
5. Create a new card
6. Upload multiple images to the new card using the share intent