### PR TITLE
[Fix] "FilesUtil" Temporary cache creation is now synchronized

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/FilesUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/FilesUtil.java
@@ -46,6 +46,19 @@ public class FilesUtil {
     }
 
     /**
+     * Creates a temporary cache directory in a synchronized manner, in order to mitigate multi-threaded collisions
+     * @param tempDir - Temporal Cache Directory
+     * @return success
+     */
+    static synchronized boolean createTempCacheDirectory(@NonNull File tempDir) {
+        if (tempDir.exists()) {
+            return true;
+        }
+
+        return tempDir.mkdirs();
+    }
+
+    /**
      * Creates a new {@link File}
      */
     public static File getTempCacheFile(@NonNull Context context, String fileName) throws IOException {
@@ -59,7 +72,7 @@ public class FilesUtil {
         }
         if (!tempDir.exists()) {
             DeckLog.verbose("-- The folder in which the new file should be created does not exist yet. Trying to create it…");
-            if (tempDir.mkdirs()) {
+            if (createTempCacheDirectory(tempDir)) {
                 DeckLog.verbose("--- Creation successful");
             } else {
                 throw new IOException("Directory for temporary file does not exist and could not be created.");


### PR DESCRIPTION
As it currently stands, when uploading multiple files at once (using the share dialog) an `IOException` is triggered.
The exception is thrown because the function that creates the temporary cache directory for the upload overlaps with itself (as we are uploading many files asynchronously).

<img width="276" alt="mpv_scxCor9Gxi" src="https://user-images.githubusercontent.com/1771953/147896411-11562f1d-91f0-4e10-9134-9db2d2ed8e1c.png">

The exception given is: `IOException: Directory for temporary file does not exist and could not be created`


This PR mitigates the error by moving the folder check and creation into a synchronized method.

This may also fix the exception `IOException: Could not delete local file after successful upload`.
I do not know for sure, but that exception was what started my investigation into fixing multi-file uploads and has since worked for me in the emulator after fixing the previous exception.

This is the second PR to fix the issue. The [Previous PR](https://github.com/stefan-niedermann/nextcloud-deck/pull/1198) was closed as it did not solve the issue very neatly.
Thanks to @desperateCoder for giving me a better solution to the issue.