### PR TITLE
[Feature] Enable card and list creation from attachment share activity

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/MainActivity.java
@@ -613,14 +613,7 @@ public class MainActivity extends AppCompatActivity implements DeleteStackListen
         binding.toolbar.setTitle(board.getTitle());
         binding.filterText.setHint(getString(R.string.search_in, board.getTitle()));
 
-        if (mainViewModel.currentBoardHasEditPermission()) {
-            binding.fab.show();
-            binding.listMenuButton.setVisibility(View.VISIBLE);
-        } else {
-            binding.fab.hide();
-            binding.listMenuButton.setVisibility(View.GONE);
-            binding.emptyContentViewStacks.hideDescription();
-        }
+        showEditButtonsIfPermissionsGranted();
 
         binding.emptyContentViewBoards.setVisibility(View.GONE);
         binding.swipeRefreshLayout.setVisibility(View.VISIBLE);
@@ -790,6 +783,17 @@ public class MainActivity extends AppCompatActivity implements DeleteStackListen
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    protected void showEditButtonsIfPermissionsGranted() {
+        if (mainViewModel.currentBoardHasEditPermission()) {
+            binding.fab.show();
+            binding.listMenuButton.setVisibility(View.VISIBLE);
+        } else {
+            binding.fab.hide();
+            binding.listMenuButton.setVisibility(View.GONE);
+            binding.emptyContentViewStacks.hideDescription();
+        }
     }
 
     protected void showFabIfEditPermissionGranted() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareTargetActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareTargetActivity.java
@@ -193,13 +193,14 @@ public class ShareTargetActivity extends MainActivity implements SelectCardListe
     @Override
     protected void setCurrentBoard(@NonNull Board board) {
         super.setCurrentBoard(board);
-        binding.listMenuButton.setVisibility(View.GONE);
-        binding.fab.setVisibility(View.GONE);
         binding.toolbar.setTitle(R.string.simple_select);
+
+        // Show Fab so we can add new lists/cards
+        showFabIfEditPermissionGranted();
     }
 
-    @Override
-    protected void showFabIfEditPermissionGranted() { /* Silence is gold */ }
+    // @Override
+    // protected void showFabIfEditPermissionGranted() { /* Silence is gold */ }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareTargetActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/sharetarget/ShareTargetActivity.java
@@ -195,8 +195,8 @@ public class ShareTargetActivity extends MainActivity implements SelectCardListe
         super.setCurrentBoard(board);
         binding.toolbar.setTitle(R.string.simple_select);
 
-        // Show Fab so we can add new lists/cards
-        showFabIfEditPermissionGranted();
+        // Show Edit buttons so we can add new lists/cards
+        showEditButtonsIfPermissionsGranted();
     }
 
     // @Override


### PR DESCRIPTION
This PR enables the `Fab` and `ListMenu` button for the `Attachment Share` activity, this allows the user to create a new list or card directly from the share activity.

There is already an [existing PR](https://github.com/stefan-niedermann/nextcloud-deck/pull/1011) that added a whole new activity for adding attachments to existing cards, I believe reusing the original activity would provide a more consistent experience and make it easier to navigate.

Here is a mini demo of how it looks:

https://user-images.githubusercontent.com/1771953/148093294-346c92d9-f584-4f90-b532-410ea87c41bd.mp4

This PR would solve the following issue: https://github.com/stefan-niedermann/nextcloud-deck/issues/613


