### PR TITLE
Enhance `ExecutorService` behavior to avoid `CursorWindowAllocationException`s

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/RequestHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/RequestHelper.java
@@ -16,7 +16,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 
 public class RequestHelper {
 
-    private static final ExecutorService executor = new ThreadPoolExecutor(10, 50, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
+    private static final ExecutorService executor = new ThreadPoolExecutor(10, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
 
     static {
         RxJavaPlugins.setErrorHandler(DeckLog::logError);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/RequestHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/RequestHelper.java
@@ -3,7 +3,9 @@ package it.niedermann.nextcloud.deck.api;
 import androidx.annotation.NonNull;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
@@ -14,7 +16,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 
 public class RequestHelper {
 
-    private static final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private static final ExecutorService executor = new ThreadPoolExecutor(10, 50, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
 
     static {
         RxJavaPlugins.setErrorHandler(DeckLog::logError);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/api/RequestHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/api/RequestHelper.java
@@ -14,7 +14,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 
 public class RequestHelper {
 
-    private static final ExecutorService executor = Executors.newCachedThreadPool();
+    private static final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     static {
         RxJavaPlugins.setErrorHandler(DeckLog::logError);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -114,7 +114,7 @@ public class SyncManager {
         this(context,
                 new DataBaseAdapter(context.getApplicationContext()),
                 new ServerAdapter(context.getApplicationContext(), ssoAccountName),
-                Executors.newCachedThreadPool(),
+                Executors.newFixedThreadPool(10),
                 SyncHelper::new);
         LastSyncUtil.init(context.getApplicationContext());
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/SyncManager.java
@@ -33,8 +33,10 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -114,7 +116,7 @@ public class SyncManager {
         this(context,
                 new DataBaseAdapter(context.getApplicationContext()),
                 new ServerAdapter(context.getApplicationContext(), ssoAccountName),
-                Executors.newFixedThreadPool(10),
+                new ThreadPoolExecutor(10, 100, 60L, TimeUnit.SECONDS, new SynchronousQueue<>()),
                 SyncHelper::new);
         LastSyncUtil.init(context.getApplicationContext());
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DataBaseAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DataBaseAdapter.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import it.niedermann.nextcloud.deck.DeckLog;
@@ -90,7 +92,7 @@ public class DataBaseAdapter {
     private final ExecutorService widgetNotifierExecutor;
 
     public DataBaseAdapter(@NonNull Context appContext) {
-        this(appContext, DeckDatabase.getInstance(appContext), Executors.newFixedThreadPool(10));
+        this(appContext, DeckDatabase.getInstance(appContext), new ThreadPoolExecutor(0, 100, 60L, TimeUnit.SECONDS, new SynchronousQueue<>()));
     }
 
     private DataBaseAdapter(@NonNull Context applicationContext, @NonNull DeckDatabase db, @NonNull ExecutorService widgetNotifierExecutor) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DataBaseAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/DataBaseAdapter.java
@@ -90,7 +90,7 @@ public class DataBaseAdapter {
     private final ExecutorService widgetNotifierExecutor;
 
     public DataBaseAdapter(@NonNull Context appContext) {
-        this(appContext, DeckDatabase.getInstance(appContext), Executors.newCachedThreadPool());
+        this(appContext, DeckDatabase.getInstance(appContext), Executors.newFixedThreadPool(10));
     }
 
     private DataBaseAdapter(@NonNull Context applicationContext, @NonNull DeckDatabase db, @NonNull ExecutorService widgetNotifierExecutor) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/LiveDataHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/LiveDataHelper.java
@@ -9,7 +9,9 @@ import androidx.lifecycle.MediatorLiveData;
 import androidx.lifecycle.Observer;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class LiveDataHelper {
 
@@ -17,7 +19,7 @@ public class LiveDataHelper {
         throw new UnsupportedOperationException("This class must not be instantiated.");
     }
 
-    private static final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private static final ExecutorService executor = new ThreadPoolExecutor(10, 100, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
 
     public static <T> LiveData<T> interceptLiveData(LiveData<T> data, DataChangeProcessor<T> onDataChange) {
         MediatorLiveData<T> ret = new MediatorLiveData<>();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/LiveDataHelper.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/persistence/sync/adapters/db/util/LiveDataHelper.java
@@ -17,7 +17,7 @@ public class LiveDataHelper {
         throw new UnsupportedOperationException("This class must not be instantiated.");
     }
 
-    private static final ExecutorService executor = Executors.newCachedThreadPool();
+    private static final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     public static <T> LiveData<T> interceptLiveData(LiveData<T> data, DataChangeProcessor<T> onDataChange) {
         MediatorLiveData<T> ret = new MediatorLiveData<>();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
@@ -93,7 +93,7 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentDelet
     private PreviewDialogViewModel previewViewModel;
     private BottomSheetBehavior<LinearLayout> mBottomSheetBehaviour;
     private boolean compressImagesOnUpload = true;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     private RecyclerView.ItemDecoration galleryItemDecoration;
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/attachments/CardAttachmentsFragment.java
@@ -54,7 +54,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import id.zelory.compressor.constraint.FormatConstraint;
 import id.zelory.compressor.constraint.QualityConstraint;
@@ -93,7 +95,7 @@ public class CardAttachmentsFragment extends Fragment implements AttachmentDelet
     private PreviewDialogViewModel previewViewModel;
     private BottomSheetBehavior<LinearLayout> mBottomSheetBehaviour;
     private boolean compressImagesOnUpload = true;
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private final ExecutorService executor = new ThreadPoolExecutor(0, 30, 10L, TimeUnit.SECONDS, new SynchronousQueue<>());
 
     private RecyclerView.ItemDecoration galleryItemDecoration;
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsViewModel.java
@@ -25,7 +25,7 @@ public class UpcomingCardsViewModel extends AndroidViewModel {
     public UpcomingCardsViewModel(@NonNull Application application) {
         super(application);
         this.syncManager = new SyncManager(application);
-        this.executor = Executors.newCachedThreadPool();
+        this.executor = Executors.newFixedThreadPool(10);
     }
 
     public LiveData<List<UpcomingCardsAdapterItem>> getUpcomingCards() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/upcomingcards/UpcomingCardsViewModel.java
@@ -8,7 +8,9 @@ import androidx.lifecycle.LiveData;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import it.niedermann.nextcloud.deck.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.model.Account;
@@ -25,7 +27,7 @@ public class UpcomingCardsViewModel extends AndroidViewModel {
     public UpcomingCardsViewModel(@NonNull Application application) {
         super(application);
         this.syncManager = new SyncManager(application);
-        this.executor = Executors.newFixedThreadPool(10);
+        this.executor = new ThreadPoolExecutor(0, 10, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
     }
 
     public LiveData<List<UpcomingCardsAdapterItem>> getUpcomingCards() {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidget.java
@@ -13,16 +13,16 @@ import androidx.annotation.NonNull;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
+import it.niedermann.nextcloud.deck.util.WidgetUtil;
 
 public class FilterWidget extends AppWidgetProvider {
     public static final String ACCOUNT_KEY = "filter_widget_account";
     public static final String BUNDLE_KEY = "filter_widget_bundle";
-    final ExecutorService executor = Executors.newFixedThreadPool(10);
+    final ExecutorService executor = WidgetUtil.newWidgetExecutorService();
 
     static void updateAppWidget(@NonNull ExecutorService executor, @NonNull Context context, AppWidgetManager awm, int[] appWidgetIds, Account account) {
         final SyncManager syncManager = new SyncManager(context);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/filter/FilterWidget.java
@@ -1,5 +1,7 @@
 package it.niedermann.nextcloud.deck.ui.widget.filter;
 
+import static android.appwidget.AppWidgetManager.ACTION_APPWIDGET_UPDATE;
+
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
@@ -17,12 +19,10 @@ import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 
-import static android.appwidget.AppWidgetManager.ACTION_APPWIDGET_UPDATE;
-
 public class FilterWidget extends AppWidgetProvider {
     public static final String ACCOUNT_KEY = "filter_widget_account";
     public static final String BUNDLE_KEY = "filter_widget_bundle";
-    final ExecutorService executor = Executors.newCachedThreadPool();
+    final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     static void updateAppWidget(@NonNull ExecutorService executor, @NonNull Context context, AppWidgetManager awm, int[] appWidgetIds, Account account) {
         final SyncManager syncManager = new SyncManager(context);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/singlecard/SingleCardWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/singlecard/SingleCardWidget.java
@@ -18,7 +18,6 @@ import androidx.annotation.NonNull;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Card;
@@ -26,10 +25,11 @@ import it.niedermann.nextcloud.deck.model.full.FullSingleCardWidgetModel;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
 import it.niedermann.nextcloud.deck.util.DateUtil;
+import it.niedermann.nextcloud.deck.util.WidgetUtil;
 
 public class SingleCardWidget extends AppWidgetProvider {
 
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private final ExecutorService executor = WidgetUtil.newWidgetExecutorService();
 
     void updateAppWidget(Context context, AppWidgetManager awm, int[] appWidgetIds) {
         final SyncManager syncManager = new SyncManager(context);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/singlecard/SingleCardWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/singlecard/SingleCardWidget.java
@@ -29,7 +29,7 @@ import it.niedermann.nextcloud.deck.util.DateUtil;
 
 public class SingleCardWidget extends AppWidgetProvider {
 
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     void updateAppWidget(Context context, AppWidgetManager awm, int[] appWidgetIds) {
         final SyncManager syncManager = new SyncManager(context);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/stack/StackWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/stack/StackWidget.java
@@ -16,7 +16,6 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
@@ -24,11 +23,12 @@ import it.niedermann.nextcloud.deck.model.Stack;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.MainActivity;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
+import it.niedermann.nextcloud.deck.util.WidgetUtil;
 
 public class StackWidget extends AppWidgetProvider {
     private static final int PENDING_INTENT_OPEN_APP_RQ = 0;
     private static final int PENDING_INTENT_EDIT_CARD_RQ = 1;
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private final ExecutorService executor = WidgetUtil.newWidgetExecutorService();
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/stack/StackWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/stack/StackWidget.java
@@ -28,7 +28,7 @@ import it.niedermann.nextcloud.deck.ui.card.EditActivity;
 public class StackWidget extends AppWidgetProvider {
     private static final int PENDING_INTENT_OPEN_APP_RQ = 0;
     private static final int PENDING_INTENT_EDIT_CARD_RQ = 1;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
@@ -38,7 +38,7 @@ public class UpcomingWidget extends AppWidgetProvider {
     private static final String PENDING_INTENT_ACTION_OPEN = "open";
     private static final String PENDING_INTENT_PARAM_LOCAL_CARD_ID = "localCardId";
     private static final String PENDING_INTENT_PARAM_ACCOUNT_ID = "accountId";
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
@@ -16,7 +16,6 @@ import androidx.annotation.NonNull;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import it.niedermann.nextcloud.deck.BuildConfig;
@@ -32,13 +31,14 @@ import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetSort;
 import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetUser;
 import it.niedermann.nextcloud.deck.persistence.sync.SyncManager;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
+import it.niedermann.nextcloud.deck.util.WidgetUtil;
 
 public class UpcomingWidget extends AppWidgetProvider {
     private static final String PENDING_INTENT_ACTION_EDIT = "edit";
     private static final String PENDING_INTENT_ACTION_OPEN = "open";
     private static final String PENDING_INTENT_PARAM_LOCAL_CARD_ID = "localCardId";
     private static final String PENDING_INTENT_PARAM_ACCOUNT_ID = "accountId";
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
+    private final ExecutorService executor = WidgetUtil.newWidgetExecutorService();
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/WidgetUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/WidgetUtil.java
@@ -3,6 +3,11 @@ package it.niedermann.nextcloud.deck.util;
 import android.app.PendingIntent;
 import android.os.Build;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 public class WidgetUtil {
 
     private WidgetUtil() {
@@ -26,5 +31,9 @@ public class WidgetUtil {
             return flags | PendingIntent.FLAG_MUTABLE;
         }
         return flags;
+    }
+
+    public static ExecutorService newWidgetExecutorService() {
+        return new ThreadPoolExecutor(0, 100, 10L, TimeUnit.SECONDS, new SynchronousQueue<>());
     }
 }


### PR DESCRIPTION
@desperateCoder I tried to find some reasonable `ExecutorService` configurations for the `SyncManager`, widgets, network requests and so on.

Could you please review the changes, try them on a production machine and give me some feedback on this one?