### PR TITLE
Fix issue #1180: Date and time picker invisible on dark mode with lig…

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDatePickerDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedDatePickerDialog.java
@@ -41,7 +41,7 @@ public class BrandedDatePickerDialog extends DatePickerDialog implements Branded
         setOkColor(buttonTextColor);
         setCancelColor(buttonTextColor);
         // Text in picker title is always white
-        setAccentColor(DeckColorUtil.contrastRatioIsSufficientBigAreas(Color.WHITE, mainColor) ? mainColor : ContextCompat.getColor(requireContext(), R.color.accent));
+        setAccentColor(DeckColorUtil.contrastRatioIsSufficientBigAreas(Color.WHITE, mainColor) ? mainColor : ContextCompat.getColor(requireContext(), R.color.accent_datetimepicker));
     }
 
     /**

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedTimePickerDialog.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/branding/BrandedTimePickerDialog.java
@@ -41,7 +41,7 @@ public class BrandedTimePickerDialog extends TimePickerDialog implements Branded
         setOkColor(buttonTextColor);
         setCancelColor(buttonTextColor);
         // Text in picker title is always white
-        setAccentColor(DeckColorUtil.contrastRatioIsSufficientBigAreas(Color.WHITE, mainColor) ? mainColor : ContextCompat.getColor(requireContext(), R.color.accent));
+        setAccentColor(DeckColorUtil.contrastRatioIsSufficientBigAreas(Color.WHITE, mainColor) ? mainColor : ContextCompat.getColor(requireContext(), R.color.accent_datetimepicker));
     }
 
     /**

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="primary">@android:color/black</color>
     <color name="accent">@android:color/white</color>
+    <color name="accent_datetimepicker">#ACACAC</color>
     <color name="fg_secondary">#666</color>
     <color name="bg_highlighted">#2a2a2a</color>
     <color name="bg_info_box">#222222</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="primary">@android:color/white</color>
     <color name="accent">#000000</color>
+    <color name="accent_datetimepicker">#000000</color>
     <color name="defaultBrand">#0082C9</color>
     <color name="danger">#d40000</color>
     <color name="fg_secondary">#999</color>


### PR DESCRIPTION
Since text in picker title is always white and cannot be changed to black then the accent color of the picker cannot be white.
A gray color as close to white as possible maintaining a contrast with the text is applied when the contrast with the main color is low - "accent_datetimepicker".