### PR TITLE
allow EditActivity to always return to main screen

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -30,6 +30,7 @@ import it.niedermann.nextcloud.deck.databinding.ActivityEditBinding;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
 import it.niedermann.nextcloud.deck.model.ocs.Version;
+import it.niedermann.nextcloud.deck.ui.MainActivity;
 import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
 import it.niedermann.nextcloud.deck.util.CardUtil;
 
@@ -174,7 +175,13 @@ public class EditActivity extends AppCompatActivity {
 
     @Override
     public boolean onSupportNavigateUp() {
-        finish(); // close this activity as oppose to navigating up
+        if(isTaskRoot()) {
+            Intent intent = new Intent(EditActivity.this, MainActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(intent);
+        } else {
+            finish();
+        }
         return true;
     }
 


### PR DESCRIPTION
Fixes #1293

See https://github.com/stefan-niedermann/nextcloud-notes/issues/1412 and https://github.com/stefan-niedermann/nextcloud-notes/pull/1536

This is basically an identical PR that allows the Edit Activity to go back to the main screen even if the card was opened from a widget.