### PR TITLE
fix: Fix invisible description on readonly boards

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
@@ -183,6 +183,8 @@ public class CardDetailsFragment extends Fragment implements CardDueDateView.Due
             viewModel.descriptionChangedFromExternal().observe(getViewLifecycleOwner(), description -> {
                 binding.descriptionViewer.setMarkdownString(description);
             });
+
+            registerEditorListener(binding.descriptionViewer);
         }
     }
 

--- a/fastlane/metadata/android/en-US/changelogs/1024002.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1024002.txt
@@ -1,0 +1,1 @@
+- 🐞 Fix invisible description on readonly boards (#1635)


### PR DESCRIPTION
Refs: https://github.com/stefan-niedermann/nextcloud-deck/issues/1635#issuecomment-2163059258