### PR TITLE
fix: description on readonly boards

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
@@ -179,7 +179,7 @@ public class CardDetailsFragment extends Fragment implements CardDueDateView.Due
 
             binding.descriptionEditor.setEnabled(false);
             binding.descriptionEditorWrapper.setVisibility(GONE);
-            binding.descriptionViewer.setEnabled(false);
+            binding.descriptionViewer.setEnabled(true);
             binding.descriptionViewer.setVisibility(VISIBLE);
 
             viewModel.descriptionChangedFromExternal().observe(getViewLifecycleOwner(), description -> {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/details/CardDetailsFragment.java
@@ -175,6 +175,8 @@ public class CardDetailsFragment extends Fragment implements CardDueDateView.Due
             registerEditorListener(binding.descriptionEditor);
             registerEditorListener(binding.descriptionViewer);
         } else {
+            binding.descriptionViewer.setMarkdownString(viewModel.getFullCard().getCard().getDescription());
+
             binding.descriptionEditor.setEnabled(false);
             binding.descriptionEditorWrapper.setVisibility(GONE);
             binding.descriptionViewer.setEnabled(false);
@@ -183,6 +185,8 @@ public class CardDetailsFragment extends Fragment implements CardDueDateView.Due
             viewModel.descriptionChangedFromExternal().observe(getViewLifecycleOwner(), description -> {
                 binding.descriptionViewer.setMarkdownString(description);
             });
+
+            registerEditorListener(binding.descriptionViewer);
         }
     }
 

--- a/app/src/main/res/layout/fragment_card_edit_tab_details.xml
+++ b/app/src/main/res/layout/fragment_card_edit_tab_details.xml
@@ -123,7 +123,7 @@
                 android:textIsSelectable="true"
                 android:textSize="@dimen/font_size_description"
                 android:translationY="1dp"
-                android:visibility="gone" />
+                android:visibility="visible" />
 
             <ImageButton
                 android:id="@+id/descriptionToggle"


### PR DESCRIPTION
- fix #1635
- closes #1641

After many attempts, I was finally able to make it! Tested with a prod server, with and without readonly boards, everything works as expected :)

| Before | After |
|--------|--------|
| ![desc-before](https://github.com/user-attachments/assets/009ec9ca-850c-4b46-af32-cb9c84e5c9eb) | ![desc-after](https://github.com/user-attachments/assets/9b411470-014e-4f99-9a4e-90776c0c6e35) | 


But I must admit I am not fully confident with the code, I never tried to play with java code before, so I don't even understand completely why those peace of code were missing...

I'd love to have your feedbacks @stefan-niedermann 