### PR TITLE
fix: card title color

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/card/EditActivity.java
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
+import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 
 import it.niedermann.android.reactivelivedata.ReactiveLiveData;
@@ -289,7 +290,7 @@ public class EditActivity extends AppCompatActivity {
 
         utils.platform.themeStatusBar(this);
         utils.material.themeToolbar(binding.toolbar);
-        utils.platform.colorEditText(binding.title);
+        utils.platform.colorTextView(binding.title, ColorRole.ON_SURFACE);
         utils.material.themeTabLayoutOnSurface(binding.tabLayout);
     }
 


### PR DESCRIPTION
On master, the `colorEditText` color is unreadable since some updates of nextcloud/android-common ([here I guess](https://github.com/nextcloud/android-common/commit/50e641ee33a834ab89315ea86bf6cb2bb0f40b58))

This commit makes the card title readable again with a more used and (stable?) function, `colorTextView` with the param `ColorRole.ON_SURFACE`

| Before | After |
|--------|--------|
| ![title-before](https://github.com/user-attachments/assets/d9911b3a-ea27-4392-b344-f56752440177) | ![title-after](https://github.com/user-attachments/assets/7cd56f8a-fa7e-40fa-b430-38e3015023e6) | 