### PR TITLE
Draft: Add optional local due reminders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,7 @@ captures/
 .kotlin
 
 # Keystore files
-# Uncomment the following line if you do not want to check your keystore files in.
-#*.jks
+*.jks
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -155,6 +155,15 @@
         </activity>
 
         <activity
+            android:name=".reminders.DueReminderActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:launchMode="singleTop"
+            android:showWhenLocked="true"
+            android:theme="@style/DueReminderTheme"
+            android:turnScreenOn="true" />
+
+        <activity
             android:name=".ui.exception.ExceptionActivity"
             android:process=":error_activity" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
 
@@ -170,6 +174,21 @@
         <service
             android:name=".ui.widget.upcoming.UpcomingWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
+
+        <receiver
+            android:name=".reminders.DueReminderReceiver"
+            android:exported="false" />
+
+        <receiver
+            android:name=".reminders.DueReminderRescheduleReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+            </intent-filter>
+        </receiver>
 
         <receiver
             android:name="it.niedermann.nextcloud.deck.ui.widget.upcoming.UpcomingWidget"

--- a/app/src/main/java/it/niedermann/nextcloud/deck/DeckApplication.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/DeckApplication.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import it.niedermann.nextcloud.deck.repository.PreferencesRepository;
+import it.niedermann.nextcloud.deck.reminders.DueReminderScheduler;
 import it.niedermann.nextcloud.deck.util.CustomAppGlideModule;
 
 public class DeckApplication extends Application {
@@ -25,6 +26,7 @@ public class DeckApplication extends Application {
 
         repo.getAppThemeSetting().thenAcceptAsync(repo::setAppTheme, executor);
         repo.isDebugModeEnabled().thenAcceptAsync(DeckLog::enablePersistentLogs, executor);
+        executor.submit(() -> DueReminderScheduler.rescheduleAll(this));
 
         super.onCreate();
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/DataBaseAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/DataBaseAdapter.java
@@ -752,6 +752,11 @@ public class DataBaseAdapter {
         return db.getCardDao().getCardByLocalIdDirectly(accountId, localCardId);
     }
 
+    @WorkerThread
+    public Card getCardByLocalIdDirectly(long localCardId) {
+        return db.getCardDao().getCardByLocalIdDirectly(localCardId);
+    }
+
     @AnyThread
     public LiveData<FullCard> getCardByLocalId(long accountId, long localCardId) {
         return new ReactiveLiveData<>(db.getCardDao().getFullCardByLocalId(accountId, localCardId))
@@ -1879,6 +1884,18 @@ public class DataBaseAdapter {
             return true;
         }
         return false;
+    }
+
+    @WorkerThread
+    public boolean markCardDoneDirectly(Long localCardId, Instant done) {
+        final Card card = db.getCardDao().getCardByLocalIdDirectly(localCardId);
+        if (card == null || Objects.equals(done, card.getDone())) {
+            return false;
+        }
+
+        card.setDone(done);
+        updateCard(card, true);
+        return true;
     }
 
     public Long getBoardRemoteIdByCardLocalIdDirectly(Long localId) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/DataBaseAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/DataBaseAdapter.java
@@ -93,6 +93,7 @@ import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetUser;
 import it.niedermann.nextcloud.deck.model.widget.filter.dto.FilterWidgetCard;
 import it.niedermann.nextcloud.deck.model.widget.singlecard.SingleCardWidgetModel;
 import it.niedermann.nextcloud.deck.remote.api.IResponseCallback;
+import it.niedermann.nextcloud.deck.reminders.DueReminderScheduler;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsAdapterItem;
 import it.niedermann.nextcloud.deck.ui.widget.singlecard.SingleCardWidget;
 import it.niedermann.nextcloud.deck.util.ExecutorServiceProvider;
@@ -779,6 +780,8 @@ public class DataBaseAdapter {
     public long createCardDirectly(long accountId, Card card) {
         card.setAccountId(accountId);
         final long newCardId = db.getCardDao().insert(card);
+        card.setLocalId(newCardId);
+        DueReminderScheduler.scheduleCard(context, card);
         notifyFilterWidgetsAboutChangedEntity(FilterWidget.EChangedEntityType.STACK, card.getStackId());
         return newCardId;
     }
@@ -802,12 +805,14 @@ public class DataBaseAdapter {
             deleteCardPhysically(card);
         }
 
+        DueReminderScheduler.cancelCard(context, card.getLocalId());
         notifyFilterWidgetsAboutChangedEntity(FilterWidget.EChangedEntityType.STACK, card.getStackId());
     }
 
     @WorkerThread
     public void deleteCardPhysically(Card card) {
         db.getCardDao().delete(card);
+        DueReminderScheduler.cancelCard(context, card.getLocalId());
     }
 
     @WorkerThread
@@ -815,6 +820,7 @@ public class DataBaseAdapter {
         markAsEditedIfNeeded(card, setStatus);
         final Long originalStackLocalId = db.getCardDao().getLocalStackIdByLocalCardId(card.getLocalId());
         db.getCardDao().update(card);
+        DueReminderScheduler.scheduleCard(context, card);
         widgetNotifierExecutor.submit(() -> {
             if (db.getSingleCardWidgetModelDao().containsCardLocalId(card.getLocalId())) {
                 DeckLog.info("Notifying", SingleCardWidget.class.getSimpleName(), "about card changes for", card.getTitle());
@@ -1419,6 +1425,16 @@ public class DataBaseAdapter {
 
     public List<UpcomingCardsAdapterItem> getCardsForUpcomingCardForWidget() {
         return cardResultsToUpcomingCardsAdapterItems(db.getCardDao().getUpcomingCardsDirectly());
+    }
+
+    @WorkerThread
+    public List<FullCard> getUpcomingFullCardsDirectly() {
+        return db.getCardDao().getUpcomingCardsDirectly();
+    }
+
+    @WorkerThread
+    public FullCard getFullCardByLocalIdDirectly(long localCardId) {
+        return db.getCardDao().getFullCardByLocalIdDirectly(localCardId);
     }
 
     @NonNull

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/dao/CardDao.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/dao/CardDao.java
@@ -51,6 +51,9 @@ public interface CardDao extends GenericDao<Card> {
     @Query("SELECT * FROM card WHERE accountId = :accountId and localId = :localId")
     Card getCardByLocalIdDirectly(final long accountId, final long localId);
 
+    @Query("SELECT * FROM card WHERE localId = :localId")
+    Card getCardByLocalIdDirectly(final long localId);
+
     @Transaction
     @Query("SELECT * FROM card WHERE accountId = :accountId and localId = :localId")
     FullCard getFullCardByLocalIdDirectly(final long accountId, final long localId);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/dao/CardDao.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/dao/CardDao.java
@@ -56,6 +56,10 @@ public interface CardDao extends GenericDao<Card> {
     FullCard getFullCardByLocalIdDirectly(final long accountId, final long localId);
 
     @Transaction
+    @Query("SELECT * FROM card WHERE localId = :localId")
+    FullCard getFullCardByLocalIdDirectly(final long localId);
+
+    @Transaction
     // v not deleted!
     @Query("SELECT * FROM card WHERE accountId = :accountId AND archived = 0 AND stackId = :localStackId and status<>3 order by `order`, createdAt asc")
     LiveData<List<FullCard>> getFullCardsForStack(final long accountId, final long localStackId);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderActivity.java
@@ -55,6 +55,7 @@ public class DueReminderActivity extends AppCompatActivity {
         }
 
         binding.dismiss.setOnClickListener((v) -> finish());
+        binding.snooze.setOnClickListener((v) -> snooze());
         binding.openCard.setOnClickListener((v) -> openCard());
         binding.markComplete.setOnClickListener((v) -> markComplete());
 
@@ -142,6 +143,18 @@ public class DueReminderActivity extends AppCompatActivity {
         });
     }
 
+    private void snooze() {
+        setLoading(true);
+        final var appContext = getApplicationContext();
+        ExecutorServiceProvider.getLinkedBlockingQueueExecutor().submit(() -> {
+            DueReminderScheduler.snooze(appContext, cardLocalId);
+            runOnUiThread(() -> {
+                Toast.makeText(this, R.string.local_due_reminder_snoozed, Toast.LENGTH_SHORT).show();
+                finish();
+            });
+        });
+    }
+
     private void openCard() {
         if (account == null || board == null) {
             return;
@@ -155,6 +168,7 @@ public class DueReminderActivity extends AppCompatActivity {
         binding.progress.setVisibility(loading ? View.VISIBLE : View.GONE);
         binding.markComplete.setEnabled(!loading);
         binding.openCard.setEnabled(!loading && account != null && board != null);
+        binding.snooze.setEnabled(!loading);
         binding.dismiss.setEnabled(!loading);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderActivity.java
@@ -1,0 +1,160 @@
+package it.niedermann.nextcloud.deck.reminders;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.NotificationManagerCompat;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.database.DataBaseAdapter;
+import it.niedermann.nextcloud.deck.databinding.ActivityDueReminderBinding;
+import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.model.Board;
+import it.niedermann.nextcloud.deck.model.Stack;
+import it.niedermann.nextcloud.deck.model.full.FullCard;
+import it.niedermann.nextcloud.deck.ui.card.EditActivity;
+import it.niedermann.nextcloud.deck.ui.exception.ExceptionHandler;
+import it.niedermann.nextcloud.deck.util.ExecutorServiceProvider;
+
+public class DueReminderActivity extends AppCompatActivity {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM);
+
+    private ActivityDueReminderBinding binding;
+    private long cardLocalId;
+    @Nullable
+    private Account account;
+    @Nullable
+    private Board board;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Thread.currentThread().setUncaughtExceptionHandler(new ExceptionHandler(this));
+        showOnLockscreen();
+
+        binding = ActivityDueReminderBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        cardLocalId = getIntent().getLongExtra(DueReminderReceiver.EXTRA_CARD_LOCAL_ID, -1L);
+        if (cardLocalId <= 0L) {
+            finish();
+            return;
+        }
+
+        binding.dismiss.setOnClickListener((v) -> finish());
+        binding.openCard.setOnClickListener((v) -> openCard());
+        binding.markComplete.setOnClickListener((v) -> markComplete());
+
+        loadReminder();
+    }
+
+    @NonNull
+    static Intent createIntent(@NonNull Context context, long cardLocalId) {
+        return new Intent(context, DueReminderActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                .putExtra(DueReminderReceiver.EXTRA_CARD_LOCAL_ID, cardLocalId);
+    }
+
+    private void showOnLockscreen() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true);
+            setTurnScreenOn(true);
+        } else {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                    | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+        }
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+
+    private void loadReminder() {
+        setLoading(true);
+        final var appContext = getApplicationContext();
+        ExecutorServiceProvider.getLinkedBlockingQueueExecutor().submit(() -> {
+            final var dataBaseAdapter = new DataBaseAdapter(appContext);
+            final FullCard fullCard = dataBaseAdapter.getFullCardByLocalIdDirectly(cardLocalId);
+            if (fullCard == null || fullCard.getCard().getDone() != null || fullCard.getCard().getDueDate() == null) {
+                runOnUiThread(() -> {
+                    Toast.makeText(this, R.string.local_due_reminder_unavailable, Toast.LENGTH_SHORT).show();
+                    finish();
+                });
+                return;
+            }
+
+            final Account loadedAccount = dataBaseAdapter.getAccountByIdDirectly(fullCard.getAccountId());
+            final Board loadedBoard = dataBaseAdapter.getBoardByLocalCardIdDirectly(cardLocalId);
+            final Stack stack = dataBaseAdapter.getStackByLocalIdDirectly(fullCard.getCard().getStackId());
+            runOnUiThread(() -> render(fullCard, loadedAccount, loadedBoard, stack));
+        });
+    }
+
+    private void render(@NonNull FullCard fullCard,
+                        @Nullable Account loadedAccount,
+                        @Nullable Board loadedBoard,
+                        @Nullable Stack stack) {
+        if (loadedAccount == null || loadedBoard == null || stack == null) {
+            Toast.makeText(this, R.string.local_due_reminder_unavailable, Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        account = loadedAccount;
+        board = loadedBoard;
+        setLoading(false);
+        final var card = fullCard.getCard();
+        final String title = card.getTitle() == null || card.getTitle().trim().isEmpty()
+                ? getString(R.string.local_due_reminder_untitled_card)
+                : card.getTitle();
+        final String dueAt = card.getDueDate()
+                .atZone(ZoneId.systemDefault())
+                .format(DATE_TIME_FORMATTER);
+
+        binding.cardTitle.setText(title);
+        binding.dueAt.setText(dueAt);
+        binding.board.setText(loadedBoard.getTitle());
+        binding.stack.setText(stack.getTitle());
+        binding.account.setText(getString(R.string.local_due_reminder_account, loadedAccount.getUserName(), loadedAccount.getUrl()));
+        binding.boardColor.setBackgroundColor(loadedBoard.getColor() == null ? getColor(R.color.defaultBrand) : loadedBoard.getColor());
+    }
+
+    private void markComplete() {
+        setLoading(true);
+        final var appContext = getApplicationContext();
+        ExecutorServiceProvider.getLinkedBlockingQueueExecutor().submit(() -> {
+            DueReminderScheduler.markComplete(appContext, cardLocalId);
+            NotificationManagerCompat.from(appContext).cancel(DueReminderScheduler.notificationId(cardLocalId));
+            runOnUiThread(() -> {
+                Toast.makeText(this, R.string.local_due_reminder_completed, Toast.LENGTH_SHORT).show();
+                finish();
+            });
+        });
+    }
+
+    private void openCard() {
+        if (account == null || board == null) {
+            return;
+        }
+
+        startActivity(EditActivity.createEditCardIntent(this, account, board.getLocalId(), cardLocalId));
+        finish();
+    }
+
+    private void setLoading(boolean loading) {
+        binding.progress.setVisibility(loading ? View.VISIBLE : View.GONE);
+        binding.markComplete.setEnabled(!loading);
+        binding.openCard.setEnabled(!loading && account != null && board != null);
+        binding.dismiss.setEnabled(!loading);
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderReceiver.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderReceiver.java
@@ -11,6 +11,8 @@ import it.niedermann.nextcloud.deck.util.ExecutorServiceProvider;
 
 public class DueReminderReceiver extends BroadcastReceiver {
 
+    static final String ACTION_SHOW_REMINDER = "it.niedermann.nextcloud.deck.reminders.SHOW_REMINDER";
+    static final String ACTION_MARK_COMPLETE = "it.niedermann.nextcloud.deck.reminders.MARK_COMPLETE";
     static final String EXTRA_CARD_LOCAL_ID = "cardLocalId";
 
     @Override
@@ -29,9 +31,14 @@ public class DueReminderReceiver extends BroadcastReceiver {
         }
 
         final var appContext = context.getApplicationContext();
+        final String action = intent.getAction();
         ExecutorServiceProvider.getLinkedBlockingQueueExecutor().submit(() -> {
             try {
-                DueReminderScheduler.showReminder(appContext, cardLocalId);
+                if (ACTION_MARK_COMPLETE.equals(action)) {
+                    DueReminderScheduler.markComplete(appContext, cardLocalId);
+                } else {
+                    DueReminderScheduler.showReminder(appContext, cardLocalId);
+                }
             } finally {
                 pendingResult.finish();
             }
@@ -40,7 +47,13 @@ public class DueReminderReceiver extends BroadcastReceiver {
 
     @NonNull
     static Intent createIntent(@NonNull Context context, long cardLocalId) {
+        return createIntent(context, ACTION_SHOW_REMINDER, cardLocalId);
+    }
+
+    @NonNull
+    static Intent createIntent(@NonNull Context context, @NonNull String action, long cardLocalId) {
         return new Intent(context, DueReminderReceiver.class)
+                .setAction(action)
                 .putExtra(EXTRA_CARD_LOCAL_ID, cardLocalId);
     }
 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderReceiver.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderReceiver.java
@@ -13,6 +13,7 @@ public class DueReminderReceiver extends BroadcastReceiver {
 
     static final String ACTION_SHOW_REMINDER = "it.niedermann.nextcloud.deck.reminders.SHOW_REMINDER";
     static final String ACTION_MARK_COMPLETE = "it.niedermann.nextcloud.deck.reminders.MARK_COMPLETE";
+    static final String ACTION_SNOOZE = "it.niedermann.nextcloud.deck.reminders.SNOOZE";
     static final String EXTRA_CARD_LOCAL_ID = "cardLocalId";
 
     @Override
@@ -36,6 +37,8 @@ public class DueReminderReceiver extends BroadcastReceiver {
             try {
                 if (ACTION_MARK_COMPLETE.equals(action)) {
                     DueReminderScheduler.markComplete(appContext, cardLocalId);
+                } else if (ACTION_SNOOZE.equals(action)) {
+                    DueReminderScheduler.snooze(appContext, cardLocalId);
                 } else {
                     DueReminderScheduler.showReminder(appContext, cardLocalId);
                 }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderReceiver.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderReceiver.java
@@ -1,0 +1,46 @@
+package it.niedermann.nextcloud.deck.reminders;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.util.ExecutorServiceProvider;
+
+public class DueReminderReceiver extends BroadcastReceiver {
+
+    static final String EXTRA_CARD_LOCAL_ID = "cardLocalId";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final PendingResult pendingResult = goAsync();
+        if (intent == null) {
+            pendingResult.finish();
+            return;
+        }
+
+        final long cardLocalId = intent.getLongExtra(EXTRA_CARD_LOCAL_ID, -1L);
+        if (cardLocalId <= 0L) {
+            DeckLog.warn("Skipping due reminder without valid card local ID.");
+            pendingResult.finish();
+            return;
+        }
+
+        final var appContext = context.getApplicationContext();
+        ExecutorServiceProvider.getLinkedBlockingQueueExecutor().submit(() -> {
+            try {
+                DueReminderScheduler.showReminder(appContext, cardLocalId);
+            } finally {
+                pendingResult.finish();
+            }
+        });
+    }
+
+    @NonNull
+    static Intent createIntent(@NonNull Context context, long cardLocalId) {
+        return new Intent(context, DueReminderReceiver.class)
+                .putExtra(EXTRA_CARD_LOCAL_ID, cardLocalId);
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderRescheduleReceiver.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderRescheduleReceiver.java
@@ -1,0 +1,20 @@
+package it.niedermann.nextcloud.deck.reminders;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.util.ExecutorServiceProvider;
+
+public class DueReminderRescheduleReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final var appContext = context.getApplicationContext();
+        ExecutorServiceProvider.getLinkedBlockingQueueExecutor().submit(() -> {
+            DeckLog.info("Rescheduling local due reminders after", intent == null ? "unknown broadcast" : intent.getAction());
+            DueReminderScheduler.rescheduleAll(appContext);
+        });
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderScheduler.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderScheduler.java
@@ -41,6 +41,7 @@ import it.niedermann.nextcloud.deck.ui.card.EditActivity;
 
 public final class DueReminderScheduler {
 
+    private static final int SNOOZE_MINUTES = 5;
     static final String CHANNEL_ID = "due_reminders";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM);
 
@@ -84,27 +85,7 @@ public final class DueReminderScheduler {
             return;
         }
 
-        final var alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        if (alarmManager == null) {
-            DeckLog.warn("Could not schedule due reminder because AlarmManager is unavailable.");
-            return;
-        }
-
-        final long dueAtMillis = card.getDueDate().toEpochMilli();
-        final PendingIntent pendingIntent = createReminderPendingIntent(context, card.getLocalId());
-
-        if (canScheduleExactAlarms(alarmManager)) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
-            } else {
-                alarmManager.setExact(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
-            }
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
-        } else {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
-        }
-
+        scheduleAt(context, card.getLocalId(), card.getDueDate().toEpochMilli());
         DeckLog.info("Scheduled due reminder for card", card.getLocalId(), "at", card.getDueDate());
     }
 
@@ -144,6 +125,7 @@ public final class DueReminderScheduler {
         final PendingIntent openCardPendingIntent = createOpenCardPendingIntent(context, account, board, cardLocalId);
         final PendingIntent fullScreenPendingIntent = createFullScreenPendingIntent(context, cardLocalId);
         final PendingIntent completePendingIntent = createCompletePendingIntent(context, cardLocalId);
+        final PendingIntent snoozePendingIntent = createSnoozePendingIntent(context, cardLocalId);
 
         final String title = context.getString(R.string.local_due_reminder_notification_title, safeTitle(fullCard.getCard()));
         final String dueAt = fullCard.getCard().getDueDate()
@@ -162,6 +144,7 @@ public final class DueReminderScheduler {
                 .setContentIntent(openCardPendingIntent)
                 .setFullScreenIntent(fullScreenPendingIntent, true)
                 .addAction(R.drawable.ic_outline_check_circle_24, context.getString(R.string.local_due_reminder_mark_complete), completePendingIntent)
+                .addAction(R.drawable.ic_time_24, context.getString(R.string.local_due_reminder_snooze), snoozePendingIntent)
                 .setAutoCancel(true)
                 .build();
 
@@ -172,6 +155,24 @@ public final class DueReminderScheduler {
         } else {
             DeckLog.warn("Skipping due reminder notification because POST_NOTIFICATIONS is not granted.");
         }
+    }
+
+    public static void snooze(@NonNull Context context, long cardLocalId) {
+        if (!isEnabled(context)) {
+            return;
+        }
+
+        final var dataBaseAdapter = new DataBaseAdapter(context.getApplicationContext());
+        final FullCard fullCard = dataBaseAdapter.getFullCardByLocalIdDirectly(cardLocalId);
+        if (fullCard == null || !shouldNotify(fullCard.getCard())) {
+            DeckLog.info("Skipping snooze for stale card", cardLocalId);
+            return;
+        }
+
+        final long snoozedUntilMillis = Instant.now().plusSeconds(SNOOZE_MINUTES * 60L).toEpochMilli();
+        scheduleAt(context, cardLocalId, snoozedUntilMillis);
+        NotificationManagerCompat.from(context).cancel(notificationId(cardLocalId));
+        DeckLog.info("Snoozed due reminder for card", cardLocalId, "until", Instant.ofEpochMilli(snoozedUntilMillis));
     }
 
     public static void markComplete(@NonNull Context context, long cardLocalId) {
@@ -198,6 +199,28 @@ public final class DueReminderScheduler {
 
     private static boolean canScheduleExactAlarms(@NonNull AlarmManager alarmManager) {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms();
+    }
+
+    private static void scheduleAt(@NonNull Context context, long cardLocalId, long triggerAtMillis) {
+        final var alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarmManager == null) {
+            DeckLog.warn("Could not schedule due reminder because AlarmManager is unavailable.");
+            return;
+        }
+
+        final PendingIntent pendingIntent = createReminderPendingIntent(context, cardLocalId);
+
+        if (canScheduleExactAlarms(alarmManager)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent);
+            } else {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent);
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent);
+        } else {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent);
+        }
     }
 
     private static boolean shouldSchedule(@NonNull Card card) {
@@ -245,6 +268,15 @@ public final class DueReminderScheduler {
                 context,
                 notificationId(cardLocalId) + 100_000,
                 DueReminderReceiver.createIntent(context, DueReminderReceiver.ACTION_MARK_COMPLETE, cardLocalId),
+                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
+        );
+    }
+
+    private static PendingIntent createSnoozePendingIntent(@NonNull Context context, long cardLocalId) {
+        return PendingIntent.getBroadcast(
+                context,
+                notificationId(cardLocalId) + 300_000,
+                DueReminderReceiver.createIntent(context, DueReminderReceiver.ACTION_SNOOZE, cardLocalId),
                 FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
         );
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderScheduler.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderScheduler.java
@@ -1,0 +1,242 @@
+package it.niedermann.nextcloud.deck.reminders;
+
+import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
+import static android.app.PendingIntent.FLAG_IMMUTABLE;
+
+import android.Manifest;
+import android.app.AlarmManager;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.provider.Settings;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.List;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.database.DataBaseAdapter;
+import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.model.Board;
+import it.niedermann.nextcloud.deck.model.Card;
+import it.niedermann.nextcloud.deck.model.enums.DBStatus;
+import it.niedermann.nextcloud.deck.model.full.FullCard;
+import it.niedermann.nextcloud.deck.ui.card.EditActivity;
+
+public final class DueReminderScheduler {
+
+    private static final String CHANNEL_ID = "due_reminders";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM);
+
+    private DueReminderScheduler() {
+    }
+
+    public static boolean isEnabled(@NonNull Context context) {
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        return preferences.getBoolean(context.getString(R.string.pref_key_local_due_reminders), true);
+    }
+
+    public static void rescheduleAll(@NonNull Context context) {
+        if (!isEnabled(context)) {
+            cancelAll(context);
+            return;
+        }
+
+        final var dataBaseAdapter = new DataBaseAdapter(context.getApplicationContext());
+        final List<FullCard> cards = dataBaseAdapter.getUpcomingFullCardsDirectly();
+        for (FullCard fullCard : cards) {
+            scheduleCard(context, fullCard.getCard());
+        }
+    }
+
+    public static void cancelAll(@NonNull Context context) {
+        final var dataBaseAdapter = new DataBaseAdapter(context.getApplicationContext());
+        final List<FullCard> cards = dataBaseAdapter.getUpcomingFullCardsDirectly();
+        for (FullCard fullCard : cards) {
+            cancelCard(context, fullCard.getCard().getLocalId());
+        }
+    }
+
+    public static void scheduleCard(@NonNull Context context, @Nullable Card card) {
+        if (card == null || card.getLocalId() == null) {
+            return;
+        }
+
+        cancelCard(context, card.getLocalId());
+
+        if (!isEnabled(context) || !shouldSchedule(card)) {
+            return;
+        }
+
+        final var alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarmManager == null) {
+            DeckLog.warn("Could not schedule due reminder because AlarmManager is unavailable.");
+            return;
+        }
+
+        final long dueAtMillis = card.getDueDate().toEpochMilli();
+        final PendingIntent pendingIntent = createReminderPendingIntent(context, card.getLocalId());
+
+        if (canScheduleExactAlarms(alarmManager)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
+            } else {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
+        } else {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, dueAtMillis, pendingIntent);
+        }
+
+        DeckLog.info("Scheduled due reminder for card", card.getLocalId(), "at", card.getDueDate());
+    }
+
+    public static void cancelCard(@NonNull Context context, @Nullable Long cardLocalId) {
+        if (cardLocalId == null || cardLocalId <= 0L) {
+            return;
+        }
+
+        final var alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarmManager != null) {
+            alarmManager.cancel(createReminderPendingIntent(context, cardLocalId));
+        }
+    }
+
+    public static void showReminder(@NonNull Context context, long cardLocalId) {
+        if (!isEnabled(context)) {
+            return;
+        }
+
+        final var dataBaseAdapter = new DataBaseAdapter(context.getApplicationContext());
+        final FullCard fullCard = dataBaseAdapter.getFullCardByLocalIdDirectly(cardLocalId);
+        if (fullCard == null || !shouldNotify(fullCard.getCard())) {
+            DeckLog.info("Skipping due reminder for stale card", cardLocalId);
+            return;
+        }
+
+        final Account account = dataBaseAdapter.getAccountByIdDirectly(fullCard.getAccountId());
+        final Board board = dataBaseAdapter.getBoardByLocalCardIdDirectly(cardLocalId);
+        if (account == null || board == null) {
+            DeckLog.warn("Skipping due reminder because account or board could not be found for card", cardLocalId);
+            return;
+        }
+
+        createNotificationChannel(context);
+
+        final Intent openCardIntent = EditActivity.createEditCardIntent(context, account, board.getLocalId(), cardLocalId);
+        final PendingIntent openCardPendingIntent = PendingIntent.getActivity(
+                context,
+                notificationId(cardLocalId),
+                openCardIntent,
+                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
+        );
+
+        final String title = context.getString(R.string.local_due_reminder_notification_title, safeTitle(fullCard.getCard()));
+        final String dueAt = fullCard.getCard().getDueDate()
+                .atZone(ZoneId.systemDefault())
+                .format(DATE_TIME_FORMATTER);
+        final String text = context.getString(R.string.local_due_reminder_notification_text, board.getTitle(), dueAt);
+
+        final var notification = new NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notifications_24)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+                .setCategory(NotificationCompat.CATEGORY_ALARM)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setContentIntent(openCardPendingIntent)
+                .setFullScreenIntent(openCardPendingIntent, true)
+                .setAutoCancel(true)
+                .build();
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+                || ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+            NotificationManagerCompat.from(context).notify(notificationId(cardLocalId), notification);
+            DeckLog.info("Displayed due reminder for card", cardLocalId);
+        } else {
+            DeckLog.warn("Skipping due reminder notification because POST_NOTIFICATIONS is not granted.");
+        }
+    }
+
+    public static boolean canScheduleExactAlarms(@NonNull Context context) {
+        final var alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        return alarmManager != null && canScheduleExactAlarms(alarmManager);
+    }
+
+    @NonNull
+    public static Intent createExactAlarmSettingsIntent(@NonNull Context context) {
+        return new Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setPackage(context.getPackageName());
+    }
+
+    private static boolean canScheduleExactAlarms(@NonNull AlarmManager alarmManager) {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms();
+    }
+
+    private static boolean shouldSchedule(@NonNull Card card) {
+        return shouldNotify(card) && card.getDueDate().isAfter(Instant.now());
+    }
+
+    private static boolean shouldNotify(@NonNull Card card) {
+        return card.getDueDate() != null
+                && card.getDone() == null
+                && !card.isArchived()
+                && card.getStatusEnum() != DBStatus.LOCAL_DELETED
+                && (card.getDeletedAt() == null || card.getDeletedAt().toEpochMilli() == 0L);
+    }
+
+    private static void createNotificationChannel(@NonNull Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        final var channel = new NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.local_due_reminders_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+        );
+        channel.setDescription(context.getString(R.string.local_due_reminders_channel_description));
+        channel.setLockscreenVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+
+        final var notificationManager = context.getSystemService(NotificationManager.class);
+        if (notificationManager != null) {
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    private static PendingIntent createReminderPendingIntent(@NonNull Context context, long cardLocalId) {
+        return PendingIntent.getBroadcast(
+                context,
+                notificationId(cardLocalId),
+                DueReminderReceiver.createIntent(context, cardLocalId),
+                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
+        );
+    }
+
+    private static int notificationId(long cardLocalId) {
+        return (int) (20_000L + cardLocalId);
+    }
+
+    @NonNull
+    private static String safeTitle(@NonNull Card card) {
+        final String title = card.getTitle();
+        return title == null || title.trim().isEmpty() ? "" : title;
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderScheduler.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/reminders/DueReminderScheduler.java
@@ -34,13 +34,14 @@ import it.niedermann.nextcloud.deck.database.DataBaseAdapter;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.model.Board;
 import it.niedermann.nextcloud.deck.model.Card;
+import it.niedermann.nextcloud.deck.model.Stack;
 import it.niedermann.nextcloud.deck.model.enums.DBStatus;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
 
 public final class DueReminderScheduler {
 
-    private static final String CHANNEL_ID = "due_reminders";
+    static final String CHANNEL_ID = "due_reminders";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM);
 
     private DueReminderScheduler() {
@@ -132,26 +133,23 @@ public final class DueReminderScheduler {
 
         final Account account = dataBaseAdapter.getAccountByIdDirectly(fullCard.getAccountId());
         final Board board = dataBaseAdapter.getBoardByLocalCardIdDirectly(cardLocalId);
-        if (account == null || board == null) {
-            DeckLog.warn("Skipping due reminder because account or board could not be found for card", cardLocalId);
+        final Stack stack = dataBaseAdapter.getStackByLocalIdDirectly(fullCard.getCard().getStackId());
+        if (account == null || board == null || stack == null) {
+            DeckLog.warn("Skipping due reminder because account, board or stack could not be found for card", cardLocalId);
             return;
         }
 
         createNotificationChannel(context);
 
-        final Intent openCardIntent = EditActivity.createEditCardIntent(context, account, board.getLocalId(), cardLocalId);
-        final PendingIntent openCardPendingIntent = PendingIntent.getActivity(
-                context,
-                notificationId(cardLocalId),
-                openCardIntent,
-                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
-        );
+        final PendingIntent openCardPendingIntent = createOpenCardPendingIntent(context, account, board, cardLocalId);
+        final PendingIntent fullScreenPendingIntent = createFullScreenPendingIntent(context, cardLocalId);
+        final PendingIntent completePendingIntent = createCompletePendingIntent(context, cardLocalId);
 
         final String title = context.getString(R.string.local_due_reminder_notification_title, safeTitle(fullCard.getCard()));
         final String dueAt = fullCard.getCard().getDueDate()
                 .atZone(ZoneId.systemDefault())
                 .format(DATE_TIME_FORMATTER);
-        final String text = context.getString(R.string.local_due_reminder_notification_text, board.getTitle(), dueAt);
+        final String text = context.getString(R.string.local_due_reminder_notification_text, board.getTitle(), stack.getTitle(), dueAt);
 
         final var notification = new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notifications_24)
@@ -162,7 +160,8 @@ public final class DueReminderScheduler {
                 .setPriority(NotificationCompat.PRIORITY_MAX)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setContentIntent(openCardPendingIntent)
-                .setFullScreenIntent(openCardPendingIntent, true)
+                .setFullScreenIntent(fullScreenPendingIntent, true)
+                .addAction(R.drawable.ic_outline_check_circle_24, context.getString(R.string.local_due_reminder_mark_complete), completePendingIntent)
                 .setAutoCancel(true)
                 .build();
 
@@ -172,6 +171,17 @@ public final class DueReminderScheduler {
             DeckLog.info("Displayed due reminder for card", cardLocalId);
         } else {
             DeckLog.warn("Skipping due reminder notification because POST_NOTIFICATIONS is not granted.");
+        }
+    }
+
+    public static void markComplete(@NonNull Context context, long cardLocalId) {
+        final var dataBaseAdapter = new DataBaseAdapter(context.getApplicationContext());
+        if (dataBaseAdapter.markCardDoneDirectly(cardLocalId, Instant.now())) {
+            cancelCard(context, cardLocalId);
+            NotificationManagerCompat.from(context).cancel(notificationId(cardLocalId));
+            DeckLog.info("Marked due reminder card complete", cardLocalId);
+        } else {
+            DeckLog.info("Skipping complete action for stale or already completed card", cardLocalId);
         }
     }
 
@@ -230,7 +240,35 @@ public final class DueReminderScheduler {
         );
     }
 
-    private static int notificationId(long cardLocalId) {
+    private static PendingIntent createCompletePendingIntent(@NonNull Context context, long cardLocalId) {
+        return PendingIntent.getBroadcast(
+                context,
+                notificationId(cardLocalId) + 100_000,
+                DueReminderReceiver.createIntent(context, DueReminderReceiver.ACTION_MARK_COMPLETE, cardLocalId),
+                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
+        );
+    }
+
+    private static PendingIntent createFullScreenPendingIntent(@NonNull Context context, long cardLocalId) {
+        return PendingIntent.getActivity(
+                context,
+                notificationId(cardLocalId),
+                DueReminderActivity.createIntent(context, cardLocalId),
+                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
+        );
+    }
+
+    static PendingIntent createOpenCardPendingIntent(@NonNull Context context, @NonNull Account account, @NonNull Board board, long cardLocalId) {
+        final Intent openCardIntent = EditActivity.createEditCardIntent(context, account, board.getLocalId(), cardLocalId);
+        return PendingIntent.getActivity(
+                context,
+                notificationId(cardLocalId) + 200_000,
+                openCardIntent,
+                FLAG_IMMUTABLE | FLAG_CANCEL_CURRENT
+        );
+    }
+
+    static int notificationId(long cardLocalId) {
         return (int) (20_000L + cardLocalId);
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/remote/SyncWorker.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/remote/SyncWorker.java
@@ -26,6 +26,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.remote.api.ResponseCallback;
+import it.niedermann.nextcloud.deck.reminders.DueReminderScheduler;
 import it.niedermann.nextcloud.deck.repository.BaseRepository;
 import it.niedermann.nextcloud.deck.repository.SyncRepository;
 import okhttp3.Headers;
@@ -54,7 +55,9 @@ public class SyncWorker extends Worker {
         editor.apply();
 
         try {
-            return synchronizeEverything(getApplicationContext(), baseRepository.readAccountsDirectly());
+            final var result = synchronizeEverything(getApplicationContext(), baseRepository.readAccountsDirectly());
+            DueReminderScheduler.rescheduleAll(getApplicationContext());
+            return result;
         } catch (NextcloudFilesAppAccountNotFoundException e) {
             return Result.failure();
         } finally {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/settings/SettingsFragment.java
@@ -1,8 +1,10 @@
 package it.niedermann.nextcloud.deck.ui.settings;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 
@@ -20,6 +22,7 @@ import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.Account;
 import it.niedermann.nextcloud.deck.remote.SyncWorker;
+import it.niedermann.nextcloud.deck.reminders.DueReminderScheduler;
 import it.niedermann.nextcloud.deck.ui.theme.ThemedSwitchPreference;
 
 public class SettingsFragment extends PreferenceFragmentCompat {
@@ -32,6 +35,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     private ThemedSwitchPreference compactPref;
     private ThemedSwitchPreference coverImagesPref;
     private ThemedSwitchPreference compressImageAttachmentsPref;
+    private ThemedSwitchPreference localDueRemindersPref;
     private ThemedSwitchPreference debuggingPref;
     private ThemedSwitchPreference eTagPref;
 
@@ -58,6 +62,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         coverImagesPref = findPreference(getString(R.string.pref_key_cover_images));
         compactPref = findPreference(getString(R.string.pref_key_compact));
         compressImageAttachmentsPref = findPreference(getString(R.string.pref_key_compress_image_attachments));
+        localDueRemindersPref = findPreference(getString(R.string.pref_key_local_due_reminders));
         eTagPref = findPreference(getString(R.string.pref_key_etags));
 
         debuggingPref = findPreference(getString(R.string.pref_key_debugging));
@@ -91,6 +96,20 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             DeckLog.error("Could not find preference with key", getString(R.string.pref_key_push_notifications));
         }
 
+        if (localDueRemindersPref != null) {
+            localDueRemindersPref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                if (Boolean.TRUE.equals(newValue)) {
+                    requestNotificationPermissionIfNeeded();
+                    DueReminderScheduler.rescheduleAll(requireContext().getApplicationContext());
+                } else {
+                    DueReminderScheduler.cancelAll(requireContext().getApplicationContext());
+                }
+                return true;
+            });
+        } else {
+            DeckLog.error("Could not find preference with key", getString(R.string.pref_key_local_due_reminders));
+        }
+
         final var themePref = findPreference(getString(R.string.pref_key_dark_theme));
         if (themePref != null) {
             themePref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
@@ -107,8 +126,14 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        Stream.of(wifiOnlyPref, compactPref, coverImagesPref, compressImageAttachmentsPref, debuggingPref, eTagPref)
+        Stream.of(wifiOnlyPref, compactPref, coverImagesPref, compressImageAttachmentsPref, localDueRemindersPref, debuggingPref, eTagPref)
                 .forEach(pref -> pref.applyTheme(account.getColor()));
+    }
+
+    private void requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 0);
+        }
     }
 
     @NonNull

--- a/app/src/main/res/layout/activity_due_reminder.xml
+++ b/app/src/main/res/layout/activity_due_reminder.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
+    android:paddingStart="24dp"
+    android:paddingTop="32dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:background="@drawable/circle_alpha_check_36dp"
+        android:contentDescription="@null"
+        android:padding="14dp"
+        android:src="@drawable/ic_notifications_24"
+        app:tint="?attr/colorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:text="@string/local_due_reminder_fullscreen_title"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        app:layout_constraintBottom_toTopOf="@id/due_at"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="@id/icon"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <TextView
+        android:id="@+id/due_at"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+        android:textColor="?attr/colorOnSurface"
+        app:layout_constraintBottom_toBottomOf="@id/icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/label"
+        app:layout_constraintTop_toBottomOf="@id/label" />
+
+    <TextView
+        android:id="@+id/card_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:ellipsize="end"
+        android:maxLines="5"
+        android:textAppearance="@style/TextAppearance.Material3.DisplaySmall"
+        android:textColor="?attr/colorOnSurface"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/icon" />
+
+    <View
+        android:id="@+id/board_color"
+        android:layout_width="6dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="28dp"
+        android:background="@color/defaultBrand"
+        app:layout_constraintBottom_toBottomOf="@id/meta_group"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/meta_group" />
+
+    <LinearLayout
+        android:id="@+id/meta_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/board_color"
+        app:layout_constraintTop_toBottomOf="@id/card_title">
+
+        <TextView
+            android:id="@+id/board"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.Material3.TitleLarge"
+            android:textColor="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/stack"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <TextView
+            android:id="@+id/account"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:ellipsize="middle"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/button_group"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/meta_group" />
+
+    <LinearLayout
+        android:id="@+id/button_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/mark_complete"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:text="@string/local_due_reminder_mark_complete"
+            app:icon="@drawable/ic_outline_check_circle_24" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/open_card"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="52dp"
+                android:layout_marginEnd="6dp"
+                android:layout_weight="1"
+                android:text="@string/local_due_reminder_open_card" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/dismiss"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="0dp"
+                android:layout_height="52dp"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1"
+                android:text="@string/local_due_reminder_dismiss" />
+        </LinearLayout>
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_due_reminder.xml
+++ b/app/src/main/res/layout/activity_due_reminder.xml
@@ -147,16 +147,27 @@
                 style="@style/Widget.Material3.Button.OutlinedButton"
                 android:layout_width="0dp"
                 android:layout_height="52dp"
-                android:layout_marginEnd="6dp"
+                android:layout_marginEnd="4dp"
                 android:layout_weight="1"
                 android:text="@string/local_due_reminder_open_card" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/snooze"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="52dp"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:text="@string/local_due_reminder_snooze_short"
+                app:icon="@drawable/ic_time_24" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/dismiss"
                 style="@style/Widget.Material3.Button.TextButton"
                 android:layout_width="0dp"
                 android:layout_height="52dp"
-                android:layout_marginStart="6dp"
+                android:layout_marginStart="4dp"
                 android:layout_weight="1"
                 android:text="@string/local_due_reminder_dismiss" />
         </LinearLayout>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -6,6 +6,7 @@
 
     <string name="pref_key_wifi_only" translatable="false">wifiOnly</string>
     <string name="pref_key_push_notifications" translatable="false">pushNotifications</string>
+    <string name="pref_key_local_due_reminders" translatable="false">localDueReminders</string>
     <string name="pref_key_dark_theme" translatable="false">darkTheme</string>
     <string name="pref_key_compact" translatable="false">compact</string>
     <string name="pref_key_cover_images" translatable="false">cover_images</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,10 +201,13 @@
     <string name="local_due_reminder_notification_text">%1$s · %2$s · %3$s</string>
     <string name="local_due_reminder_fullscreen_title">Due reminder</string>
     <string name="local_due_reminder_mark_complete">Mark complete</string>
+    <string name="local_due_reminder_snooze">Snooze 5 min</string>
+    <string name="local_due_reminder_snooze_short">Snooze</string>
     <string name="local_due_reminder_open_card">Open card</string>
     <string name="local_due_reminder_dismiss">Dismiss</string>
     <string name="local_due_reminder_account">%1$s on %2$s</string>
     <string name="local_due_reminder_completed">Card marked complete</string>
+    <string name="local_due_reminder_snoozed">Snoozed for 5 minutes</string>
     <string name="local_due_reminder_unavailable">This reminder is no longer available</string>
     <string name="local_due_reminder_untitled_card">Untitled card</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,7 +198,15 @@
     <string name="local_due_reminders_channel_name">Due reminders</string>
     <string name="local_due_reminders_channel_description">Card due-date reminders from Deck</string>
     <string name="local_due_reminder_notification_title">%1$s is due</string>
-    <string name="local_due_reminder_notification_text">%1$s · %2$s</string>
+    <string name="local_due_reminder_notification_text">%1$s · %2$s · %3$s</string>
+    <string name="local_due_reminder_fullscreen_title">Due reminder</string>
+    <string name="local_due_reminder_mark_complete">Mark complete</string>
+    <string name="local_due_reminder_open_card">Open card</string>
+    <string name="local_due_reminder_dismiss">Dismiss</string>
+    <string name="local_due_reminder_account">%1$s on %2$s</string>
+    <string name="local_due_reminder_completed">Card marked complete</string>
+    <string name="local_due_reminder_unavailable">This reminder is no longer available</string>
+    <string name="local_due_reminder_untitled_card">Untitled card</string>
 
     <string name="move_list_right">Move list right</string>
     <string name="move_list_left">Move list left</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="settings_etags_summary">Speeds up synchronization</string>
     <string name="settings_background_sync">Background synchronization</string>
     <string name="settings_push_notifications">Push notifications</string>
+    <string name="settings_local_due_reminders">Local due reminders</string>
+    <string name="settings_local_due_reminders_summary">Show reminders from synced card due dates, even without Google Play push.</string>
     <string name="settings_compress_image_attachments">Compress images on upload</string>
     <string name="search_in">Search in %1$s</string>
     <string name="settings_compress_image_attachments_summary">Faster upload, less quality</string>
@@ -193,6 +195,10 @@
     <string name="task_count">%1$s/%2$s</string>
     <string name="open_in_browser">Open in browser</string>
     <string name="updating_card">Updating card…</string>
+    <string name="local_due_reminders_channel_name">Due reminders</string>
+    <string name="local_due_reminders_channel_description">Card due-date reminders from Deck</string>
+    <string name="local_due_reminder_notification_title">%1$s is due</string>
+    <string name="local_due_reminder_notification_text">%1$s · %2$s</string>
 
     <string name="move_list_right">Move list right</string>
     <string name="move_list_left">Move list left</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -109,6 +109,13 @@
         <item name="android:statusBarColor">@android:color/background_dark</item>
     </style>
 
+    <style name="DueReminderTheme" parent="AppTheme">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+    </style>
+
     <style name="TakePhotoTheme" parent="TransparentTheme">
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowContentOverlay">@null</item>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -28,6 +28,13 @@
             android:key="@string/pref_key_push_notifications"
             android:icon="@drawable/ic_notifications_24"
             android:title="@string/settings_push_notifications" />
+
+        <it.niedermann.nextcloud.deck.ui.theme.ThemedSwitchPreference
+            android:defaultValue="true"
+            android:icon="@drawable/ic_notifications_24"
+            android:key="@string/pref_key_local_due_reminders"
+            android:summary="@string/settings_local_due_reminders_summary"
+            android:title="@string/settings_local_due_reminders" />
     </it.niedermann.nextcloud.deck.ui.theme.ThemedPreferenceCategory>
 
     <it.niedermann.nextcloud.deck.ui.theme.ThemedPreferenceCategory android:title="@string/simple_appearance">


### PR DESCRIPTION
## Context

This is a draft/reference PR for an optional local due-reminder implementation. I understand this may not match the project's product philosophy or maintenance direction, so I am opening it as a draft rather than asking for immediate merge consideration.

The main goal is to make the patch visible for people who want local device reminders without google play or extra server setup.

The code is fully generated, a working version and poc was the only goal!

## What this patch does

- Adds an optional setting for local due reminders, circumventing the need for the nextcloud files app and setting up server notifications there. It works without google play.
- Schedules local reminders for cards with due dates after sync/database updates.
- Reschedules reminders after reboot/package replacement/time changes.
- Shows a local reminder notification/fullscreen reminder activity.
- Includes snooze support from the reminder UI.

## Notes

- This branch currently targets the F-Droid/release application id, not the dev flavor.
- A signed fork build is available here for users who want to test the behavior: https://github.com/default-student/nextcloud-deck/releases/tag/v1.25.5-local-reminders.1
- I am happy for this to remain a reference PR if upstream does not want to carry local reminder behavior.

## Testing

- Built `app:assembleFdroidRelease` successfully.
- Verified the release APK signature locally with `apksigner verify`.
- Full automated test suite has not been run yet.

Thank you for your Software!