### PR TITLE
[feat] configurable style screen for Upcoming widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -172,6 +172,13 @@
             android:name=".ui.widget.upcoming.UpcomingWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
 
+        <activity android:name=".ui.widget.upcoming.UpcomingWidgetConfigurationActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
         <receiver
             android:name="it.niedermann.nextcloud.deck.ui.widget.upcoming.UpcomingWidget"
             android:label="@string/widget_upcoming_title"

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/DeckDatabase.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/DeckDatabase.java
@@ -69,6 +69,7 @@ import it.niedermann.nextcloud.deck.database.migration.Migration_31_32;
 import it.niedermann.nextcloud.deck.database.migration.Migration_32_33;
 import it.niedermann.nextcloud.deck.database.migration.Migration_33_34;
 import it.niedermann.nextcloud.deck.database.migration.Migration_34_35;
+import it.niedermann.nextcloud.deck.database.migration.Migration_35_36;
 import it.niedermann.nextcloud.deck.database.migration.Migration_8_9;
 import it.niedermann.nextcloud.deck.database.migration.Migration_9_10;
 import it.niedermann.nextcloud.deck.model.AccessControl;
@@ -141,7 +142,7 @@ import it.niedermann.nextcloud.deck.remote.api.LastSyncUtil;
                 FilterWidgetSort.class,
         },
         exportSchema = false,
-        version = 35
+        version = 36
 )
 @TypeConverters({DateTypeConverter.class, EnumConverter.class})
 public abstract class DeckDatabase extends RoomDatabase {
@@ -197,6 +198,7 @@ public abstract class DeckDatabase extends RoomDatabase {
                 .addMigrations(new Migration_32_33())
                 .addMigrations(new Migration_33_34())
                 .addMigrations(new Migration_34_35())
+                .addMigrations(new Migration_35_36())
                 .fallbackToDestructiveMigration()
                 .addCallback(ON_CREATE_CALLBACK)
                 .build();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/migration/Migration_35_36.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/migration/Migration_35_36.java
@@ -1,0 +1,24 @@
+package it.niedermann.nextcloud.deck.database.migration;
+
+import androidx.annotation.NonNull;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+/**
+ * Adds appearance configuration options to the Upcoming widget: https://github.com/stefan-niedermann/nextcloud-deck/issues/1792
+ */
+public class Migration_35_36 extends Migration {
+
+    public Migration_35_36() {
+        super(35, 36);
+    }
+
+    @Override
+    public void migrate(@NonNull SupportSQLiteDatabase database) {
+        database.execSQL("ALTER TABLE `FilterWidget` add column titleColor INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` add column widgetBackgroundColor INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` add column sectionTextColor INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` add column listBackgroundColor INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` add column entryTextColor INTEGER");
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/widget/filter/FilterWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/widget/filter/FilterWidget.java
@@ -1,5 +1,6 @@
 package it.niedermann.nextcloud.deck.model.widget.filter;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.room.Entity;
@@ -20,6 +21,26 @@ public class FilterWidget {
 
     @Nullable
     private String title;
+
+    @Nullable
+    @ColorInt
+    private Integer titleColor;
+
+    @Nullable
+    @ColorInt
+    private Integer widgetBackgroundColor;
+
+    @Nullable
+    @ColorInt
+    private Integer sectionTextColor;
+
+    @Nullable
+    @ColorInt
+    private Integer listBackgroundColor;
+
+    @Nullable
+    @ColorInt
+    private Integer entryTextColor;
 
     @Nullable
     private EDueType dueType;
@@ -106,6 +127,56 @@ public class FilterWidget {
         this.title = title;
     }
 
+    @Nullable
+    @ColorInt
+    public Integer getTitleColor() {
+        return titleColor;
+    }
+
+    public void setTitleColor(@Nullable @ColorInt Integer titleColor) {
+        this.titleColor = titleColor;
+    }
+
+    @Nullable
+    @ColorInt
+    public Integer getWidgetBackgroundColor() {
+        return widgetBackgroundColor;
+    }
+
+    public void setWidgetBackgroundColor(@Nullable @ColorInt Integer widgetBackgroundColor) {
+        this.widgetBackgroundColor = widgetBackgroundColor;
+    }
+
+    @Nullable
+    @ColorInt
+    public Integer getSectionTextColor() {
+        return sectionTextColor;
+    }
+
+    public void setSectionTextColor(@Nullable @ColorInt Integer sectionTextColor) {
+        this.sectionTextColor = sectionTextColor;
+    }
+
+    @Nullable
+    @ColorInt
+    public Integer getListBackgroundColor() {
+        return listBackgroundColor;
+    }
+
+    public void setListBackgroundColor(@Nullable @ColorInt Integer listBackgroundColor) {
+        this.listBackgroundColor = listBackgroundColor;
+    }
+
+    @Nullable
+    @ColorInt
+    public Integer getEntryTextColor() {
+        return entryTextColor;
+    }
+
+    public void setEntryTextColor(@Nullable @ColorInt Integer entryTextColor) {
+        this.entryTextColor = entryTextColor;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -115,6 +186,11 @@ public class FilterWidget {
 
         if (id != that.id) return false;
         if (!Objects.equals(title, that.title)) return false;
+        if (!Objects.equals(titleColor, that.titleColor)) return false;
+        if (!Objects.equals(widgetBackgroundColor, that.widgetBackgroundColor)) return false;
+        if (!Objects.equals(sectionTextColor, that.sectionTextColor)) return false;
+        if (!Objects.equals(listBackgroundColor, that.listBackgroundColor)) return false;
+        if (!Objects.equals(entryTextColor, that.entryTextColor)) return false;
         if (dueType != that.dueType) return false;
         if (widgetType != that.widgetType) return false;
         if (!accounts.equals(that.accounts)) return false;
@@ -125,6 +201,11 @@ public class FilterWidget {
     public int hashCode() {
         int result = id;
         result = 31 * result + (title != null ? title.hashCode() : 0);
+        result = 31 * result + (titleColor != null ? titleColor.hashCode() : 0);
+        result = 31 * result + (widgetBackgroundColor != null ? widgetBackgroundColor.hashCode() : 0);
+        result = 31 * result + (sectionTextColor != null ? sectionTextColor.hashCode() : 0);
+        result = 31 * result + (listBackgroundColor != null ? listBackgroundColor.hashCode() : 0);
+        result = 31 * result + (entryTextColor != null ? entryTextColor.hashCode() : 0);
         result = 31 * result + (dueType != null ? dueType.hashCode() : 0);
         result = 31 * result + widgetType.hashCode();
         result = 31 * result + accounts.hashCode();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/repository/BaseRepository.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/repository/BaseRepository.java
@@ -513,6 +513,21 @@ public class BaseRepository {
     }
 
     @WorkerThread
+    public FilterWidget getFilterWidgetByIdDirectly(@NonNull Integer filterWidgetId) {
+        return dataBaseAdapter.getFilterWidgetByIdDirectly(filterWidgetId);
+    }
+
+    @WorkerThread
+    public int createFilterWidgetDirectly(@NonNull FilterWidget filterWidget) {
+        return dataBaseAdapter.createFilterWidgetDirectly(filterWidget);
+    }
+
+    @WorkerThread
+    public void updateFilterWidgetDirectly(@NonNull FilterWidget filterWidget) {
+        dataBaseAdapter.updateFilterWidgetDirectly(filterWidget);
+    }
+
+    @WorkerThread
     public List<FilterWidgetCard> getCardsForFilterWidget(@NonNull Integer filterWidgetId) {
         return dataBaseAdapter.getCardsForFilterWidget(filterWidgetId);
     }

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/WidgetColorPickerDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/WidgetColorPickerDialogFragment.java
@@ -1,0 +1,99 @@
+package it.niedermann.nextcloud.deck.ui.widget;
+
+import android.app.Dialog;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.databinding.DialogWidgetColorPickerBinding;
+
+/**
+ * Generic color picker dialog used by widget configuration screens. Unlike
+ * {@link it.niedermann.nextcloud.deck.ui.card.details.PickColorDialogFragment}, this dialog is
+ * not tied to a specific {@link androidx.lifecycle.ViewModel} — the result is reported back via
+ * the Fragment Result API so it can be reused for several independent color settings on the same
+ * screen, distinguished by {@link #resultKeyFor(String)}.
+ */
+public class WidgetColorPickerDialogFragment extends DialogFragment {
+
+    private static final String ARG_RESULT_KEY = "resultKey";
+    private static final String ARG_INITIAL_COLOR = "initialColor";
+    private static final String ARG_ALLOW_TRANSPARENT = "allowTransparent";
+
+    public static final String EXTRA_COLOR = "color";
+    public static final String EXTRA_USE_DEFAULT = "useDefault";
+
+    private DialogWidgetColorPickerBinding binding;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        binding = DialogWidgetColorPickerBinding.inflate(requireActivity().getLayoutInflater());
+
+        final var args = requireArguments();
+        final String resultKey = args.getString(ARG_RESULT_KEY);
+        final boolean allowTransparent = args.getBoolean(ARG_ALLOW_TRANSPARENT);
+        final boolean hasInitialColor = args.containsKey(ARG_INITIAL_COLOR);
+        @ColorInt final int initialColor = hasInitialColor ? args.getInt(ARG_INITIAL_COLOR) : Color.WHITE;
+
+        if (allowTransparent) {
+            binding.transparentCheckbox.setVisibility(View.VISIBLE);
+            binding.transparentCheckbox.setOnCheckedChangeListener((buttonView, isChecked) ->
+                    binding.colorChooser.setVisibility(isChecked ? View.GONE : View.VISIBLE));
+            final boolean isTransparent = hasInitialColor && Color.alpha(initialColor) == 0;
+            binding.transparentCheckbox.setChecked(isTransparent);
+            binding.colorChooser.setVisibility(isTransparent ? View.GONE : View.VISIBLE);
+        }
+
+        binding.colorChooser.selectColor(hasInitialColor ? initialColor : Color.WHITE);
+
+        return new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.choose_color)
+                .setView(binding.getRoot())
+                .setPositiveButton(R.string.simple_save, (dialog, which) -> {
+                    final boolean transparent = allowTransparent && binding.transparentCheckbox.isChecked();
+                    final int color = transparent ? Color.TRANSPARENT : binding.colorChooser.getSelectedColor();
+                    final var result = new Bundle();
+                    result.putInt(EXTRA_COLOR, color);
+                    getParentFragmentManager().setFragmentResult(resultKeyFor(resultKey), result);
+                })
+                .setNeutralButton(R.string.widget_color_use_default, (dialog, which) -> {
+                    final var result = new Bundle();
+                    result.putBoolean(EXTRA_USE_DEFAULT, true);
+                    getParentFragmentManager().setFragmentResult(resultKeyFor(resultKey), result);
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
+    @NonNull
+    public static String resultKeyFor(@NonNull String key) {
+        return "widget_color_picker_result:" + key;
+    }
+
+    public static WidgetColorPickerDialogFragment newInstance(@NonNull String resultKey, @Nullable @ColorInt Integer initialColor, boolean allowTransparent) {
+        final var fragment = new WidgetColorPickerDialogFragment();
+        final var args = new Bundle();
+        args.putString(ARG_RESULT_KEY, resultKey);
+        args.putBoolean(ARG_ALLOW_TRANSPARENT, allowTransparent);
+        if (initialColor != null) {
+            args.putInt(ARG_INITIAL_COLOR, initialColor);
+        }
+        fragment.setArguments(args);
+        return fragment;
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
@@ -10,11 +10,13 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.widget.RemoteViews;
 
 import androidx.annotation.NonNull;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -32,6 +34,7 @@ import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetUser;
 import it.niedermann.nextcloud.deck.remote.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.repository.BaseRepository;
 import it.niedermann.nextcloud.deck.ui.card.EditActivity;
+import it.niedermann.nextcloud.deck.util.WidgetUtil;
 import okhttp3.Headers;
 
 public class UpcomingWidget extends AppWidgetProvider {
@@ -120,6 +123,7 @@ public class UpcomingWidget extends AppWidgetProvider {
     }
 
     private static void updateAppWidget(@NonNull ExecutorService executor, @NonNull Context context, @NonNull AppWidgetManager awm, int[] appWidgetIds) {
+        final BaseRepository baseRepository = new BaseRepository(context);
         for (int appWidgetId : appWidgetIds) {
             executor.submit(() -> {
                 final RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_upcoming);
@@ -133,6 +137,20 @@ public class UpcomingWidget extends AppWidgetProvider {
                 views.setPendingIntentTemplate(R.id.upcoming_widget_lv, templatePI);
                 views.setRemoteAdapter(R.id.upcoming_widget_lv, serviceIntent);
                 views.setEmptyView(R.id.upcoming_widget_lv, R.id.widget_upcoming_placeholder_iv);
+
+                try {
+                    final FilterWidget config = baseRepository.getFilterWidgetByIdDirectly(appWidgetId);
+                    final String title = config.getTitle();
+                    views.setTextViewText(R.id.upcoming_widget_title_tv, TextUtils.isEmpty(title) ? context.getString(R.string.app_name_short) : title);
+                    if (config.getTitleColor() != null) {
+                        views.setTextColor(R.id.upcoming_widget_title_tv, config.getTitleColor());
+                    }
+                    if (config.getWidgetBackgroundColor() != null) {
+                        WidgetUtil.applyBackgroundColor(views, R.id.upcoming_widget_root, config.getWidgetBackgroundColor());
+                    }
+                } catch (NoSuchElementException e) {
+                    views.setTextViewText(R.id.upcoming_widget_title_tv, context.getString(R.string.app_name_short));
+                }
 
                 awm.notifyAppWidgetViewDataChanged(appWidgetId, R.id.upcoming_widget_lv);
                 awm.updateAppWidget(appWidgetId, views);

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationActivity.java
@@ -1,0 +1,155 @@
+package it.niedermann.nextcloud.deck.ui.widget.upcoming;
+
+import android.appwidget.AppWidgetManager;
+import android.content.Intent;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.widget.ImageView;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.ViewModelProvider;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.databinding.ActivityUpcomingWidgetConfigurationBinding;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
+import it.niedermann.nextcloud.deck.ui.theme.DeckViewThemeUtils;
+import it.niedermann.nextcloud.deck.ui.widget.WidgetColorPickerDialogFragment;
+
+public class UpcomingWidgetConfigurationActivity extends AppCompatActivity {
+
+    private static final String RESULT_KEY_TITLE_COLOR = "titleColor";
+    private static final String RESULT_KEY_WIDGET_BACKGROUND = "widgetBackground";
+    private static final String RESULT_KEY_SECTION_TEXT = "sectionText";
+    private static final String RESULT_KEY_LIST_BACKGROUND = "listBackground";
+    private static final String RESULT_KEY_ENTRY_TEXT = "entryText";
+
+    private int appWidgetId;
+    private ActivityUpcomingWidgetConfigurationBinding binding;
+    private UpcomingWidgetConfigurationViewModel viewModel;
+
+    @Nullable
+    private FilterWidget config;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        binding = ActivityUpcomingWidgetConfigurationBinding.inflate(getLayoutInflater());
+        viewModel = new ViewModelProvider(this).get(UpcomingWidgetConfigurationViewModel.class);
+
+        setContentView(binding.getRoot());
+        setSupportActionBar(binding.toolbar);
+
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setTitle(R.string.configure_upcoming_widget);
+        }
+
+        setResult(RESULT_CANCELED);
+        final Bundle args = getIntent().getExtras();
+
+        if (args != null) {
+            appWidgetId = args.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID);
+        }
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            DeckLog.error("INVALID_APPWIDGET_ID");
+            finish();
+            return;
+        }
+
+        setupColorRow(binding.titleColorSwatch, RESULT_KEY_TITLE_COLOR, false, FilterWidget::getTitleColor, FilterWidget::setTitleColor);
+        setupColorRow(binding.widgetBackgroundSwatch, RESULT_KEY_WIDGET_BACKGROUND, true, FilterWidget::getWidgetBackgroundColor, FilterWidget::setWidgetBackgroundColor);
+        setupColorRow(binding.sectionTextSwatch, RESULT_KEY_SECTION_TEXT, false, FilterWidget::getSectionTextColor, FilterWidget::setSectionTextColor);
+        setupColorRow(binding.listBackgroundSwatch, RESULT_KEY_LIST_BACKGROUND, true, FilterWidget::getListBackgroundColor, FilterWidget::setListBackgroundColor);
+        setupColorRow(binding.entryTextSwatch, RESULT_KEY_ENTRY_TEXT, false, FilterWidget::getEntryTextColor, FilterWidget::setEntryTextColor);
+
+        binding.cancel.setOnClickListener((v) -> finish());
+        binding.submit.setOnClickListener((v) -> submit());
+
+        viewModel.getConfig().observe(this, this::applyConfig);
+        viewModel.loadConfig(appWidgetId);
+    }
+
+    private void applyConfig(@Nullable FilterWidget config) {
+        if (config == null) {
+            return;
+        }
+        this.config = config;
+        binding.titleEt.setText(config.getTitle());
+        updateSwatch(binding.titleColorSwatch, config.getTitleColor());
+        updateSwatch(binding.widgetBackgroundSwatch, config.getWidgetBackgroundColor());
+        updateSwatch(binding.sectionTextSwatch, config.getSectionTextColor());
+        updateSwatch(binding.listBackgroundSwatch, config.getListBackgroundColor());
+        updateSwatch(binding.entryTextSwatch, config.getEntryTextColor());
+    }
+
+    private void setupColorRow(@NonNull ImageView swatch, @NonNull String resultKey, boolean allowTransparent, @NonNull ColorGetter getter, @NonNull ColorSetter setter) {
+        getSupportFragmentManager().setFragmentResultListener(WidgetColorPickerDialogFragment.resultKeyFor(resultKey), this, (requestKey, bundle) -> {
+            if (config == null) {
+                return;
+            }
+            final Integer color = bundle.getBoolean(WidgetColorPickerDialogFragment.EXTRA_USE_DEFAULT)
+                    ? null
+                    : bundle.getInt(WidgetColorPickerDialogFragment.EXTRA_COLOR);
+            setter.set(config, color);
+            updateSwatch(swatch, color);
+        });
+        swatch.setOnClickListener((v) -> {
+            if (config == null) {
+                return;
+            }
+            WidgetColorPickerDialogFragment.newInstance(resultKey, getter.get(config), allowTransparent)
+                    .show(getSupportFragmentManager(), resultKey);
+        });
+    }
+
+    private void updateSwatch(@NonNull ImageView swatch, @Nullable @ColorInt Integer color) {
+        if (color == null) {
+            swatch.setImageDrawable(DeckViewThemeUtils.getTintedImageView(this, R.drawable.circle_36dp, ContextCompat.getColor(this, R.color.board_default_custom_color)));
+        } else if (Color.alpha(color) == 0) {
+            swatch.setImageDrawable(DeckViewThemeUtils.getTintedImageView(this, R.drawable.circle_alpha_colorize_36dp, ContextCompat.getColor(this, R.color.board_default_custom_color)));
+        } else {
+            swatch.setImageDrawable(DeckViewThemeUtils.getTintedImageView(this, R.drawable.circle_36dp, color));
+        }
+    }
+
+    private void submit() {
+        if (config == null) {
+            return;
+        }
+        final String title = binding.titleEt.getText() == null ? null : binding.titleEt.getText().toString().trim();
+        config.setTitle(TextUtils.isEmpty(title) ? null : title);
+
+        viewModel.saveConfig(config, () -> {
+            final Intent updateIntent = new Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE, null, getApplicationContext(), UpcomingWidget.class)
+                    .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+            setResult(RESULT_OK, updateIntent);
+            getApplicationContext().sendBroadcast(updateIntent);
+            finish();
+        });
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        this.binding = null;
+    }
+
+    private interface ColorGetter {
+        @Nullable
+        @ColorInt
+        Integer get(@NonNull FilterWidget config);
+    }
+
+    private interface ColorSetter {
+        void set(@NonNull FilterWidget config, @Nullable @ColorInt Integer color);
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationViewModel.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationViewModel.java
@@ -1,0 +1,81 @@
+package it.niedermann.nextcloud.deck.ui.widget.upcoming;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import it.niedermann.nextcloud.deck.model.Account;
+import it.niedermann.nextcloud.deck.model.enums.ESortCriteria;
+import it.niedermann.nextcloud.deck.model.widget.filter.EWidgetType;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetAccount;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetSort;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidgetUser;
+import it.niedermann.nextcloud.deck.ui.viewmodel.BaseViewModel;
+
+public class UpcomingWidgetConfigurationViewModel extends BaseViewModel {
+
+    @NonNull
+    private final MutableLiveData<FilterWidget> config$ = new MutableLiveData<>();
+
+    public UpcomingWidgetConfigurationViewModel(@NonNull Application application) {
+        super(application);
+    }
+
+    @NonNull
+    public LiveData<FilterWidget> getConfig() {
+        return config$;
+    }
+
+    /**
+     * Loads the existing configuration for {@param appWidgetId} (the "Edit widget" path), or
+     * builds the same default configuration {@link UpcomingWidget#onUpdate} would create for a
+     * freshly placed widget (all accounts, sorted by due date) when none exists yet.
+     */
+    public void loadConfig(int appWidgetId) {
+        executor.submit(() -> {
+            final FilterWidget config;
+            try {
+                config = baseRepository.getFilterWidgetByIdDirectly(appWidgetId);
+            } catch (NoSuchElementException e) {
+                config$.postValue(buildDefaultConfig(appWidgetId));
+                return;
+            }
+            config$.postValue(config);
+        });
+    }
+
+    @NonNull
+    private FilterWidget buildDefaultConfig(int appWidgetId) {
+        final FilterWidget config = new FilterWidget(appWidgetId, EWidgetType.UPCOMING_WIDGET);
+        config.setSorts(new FilterWidgetSort(ESortCriteria.DUE_DATE, true));
+        final List<Account> accountsList = baseRepository.readAccountsDirectly();
+        config.setAccounts(accountsList.stream().map(account -> {
+            final FilterWidgetAccount fwa = new FilterWidgetAccount(account.getId(), false);
+            fwa.setUsers(new FilterWidgetUser(baseRepository.getUserByUidDirectly(account.getId(), account.getUserName()).getLocalId()));
+            return fwa;
+        }).collect(Collectors.toList()));
+        return config;
+    }
+
+    public interface SaveCallback {
+        void onSaved();
+    }
+
+    public void saveConfig(@NonNull FilterWidget config, @NonNull SaveCallback callback) {
+        executor.submit(() -> {
+            if (baseRepository.filterWidgetExists(config.getId())) {
+                baseRepository.updateFilterWidgetDirectly(config);
+            } else {
+                baseRepository.createFilterWidgetDirectly(config);
+            }
+            callback.onSaved();
+        });
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetFactory.java
@@ -7,6 +7,7 @@ import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,10 +16,12 @@ import java.util.NoSuchElementException;
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
 import it.niedermann.nextcloud.deck.repository.BaseRepository;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsAdapterItem;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsAdapterSectionItem;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsUtil;
+import it.niedermann.nextcloud.deck.util.WidgetUtil;
 
 public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFactory {
     private final Context context;
@@ -26,6 +29,9 @@ public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFact
     private final BaseRepository baseRepository;
     private final int headerHorizontalPadding;
     private final int headerVerticalPaddingNth;
+
+    @Nullable
+    private FilterWidget config;
 
     @NonNull
     private final List<Object> data = new ArrayList<>();
@@ -48,6 +54,7 @@ public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFact
     @Override
     public void onDataSetChanged() {
         try {
+            config = baseRepository.getFilterWidgetByIdDirectly(appWidgetId);
             final List<UpcomingCardsAdapterItem> response = baseRepository.getCardsForUpcomingCardsForWidget();
             DeckLog.verbose(UpcomingWidgetFactory.class.getSimpleName(), "with id", appWidgetId, "fetched", response.size(), "cards from the database.");
             data.clear();
@@ -84,11 +91,22 @@ public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFact
             } else {
                 widget_entry.setViewPadding(R.id.widget_entry_content_tv, headerHorizontalPadding, headerVerticalPaddingNth, headerHorizontalPadding, 0);
             }
+            if (config != null && config.getSectionTextColor() != null) {
+                widget_entry.setTextColor(R.id.widget_entry_content_tv, config.getSectionTextColor());
+            }
             widget_entry.setOnClickFillInIntent(R.id.widget_stack_entry, UpcomingWidget.fillOpenPendingIntent());
         } else if (data.get(i).getClass() == UpcomingCardsAdapterItem.class || data.get(i) instanceof UpcomingCardsAdapterItem) {
             final FullCard card = ((UpcomingCardsAdapterItem) data.get(i)).getFullCard();
             widget_entry = new RemoteViews(context.getPackageName(), R.layout.widget_stack_entry);
             widget_entry.setTextViewText(R.id.widget_entry_content_tv, card.getCard().getTitle());
+            if (config != null) {
+                if (config.getEntryTextColor() != null) {
+                    widget_entry.setTextColor(R.id.widget_entry_content_tv, config.getEntryTextColor());
+                }
+                if (config.getListBackgroundColor() != null) {
+                    WidgetUtil.applyBackgroundColor(widget_entry, R.id.widget_stack_entry, config.getListBackgroundColor());
+                }
+            }
             widget_entry.setOnClickFillInIntent(R.id.widget_stack_entry, UpcomingWidget.fillEditPendingIntent(card.getAccountId(), card.getLocalId()));
         } else {
             DeckLog.logError(new IllegalStateException("Expected items to be instance of " + UpcomingCardsAdapterSectionItem.class.getSimpleName() + " or " + UpcomingCardsAdapterItem.class.getSimpleName()));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/util/WidgetUtil.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/util/WidgetUtil.java
@@ -1,7 +1,11 @@
 package it.niedermann.nextcloud.deck.util;
 
 import android.app.PendingIntent;
+import android.content.res.ColorStateList;
 import android.os.Build;
+import android.widget.RemoteViews;
+
+import androidx.annotation.ColorInt;
 
 public class WidgetUtil {
 
@@ -26,5 +30,21 @@ public class WidgetUtil {
             return flags | PendingIntent.FLAG_MUTABLE;
         }
         return flags;
+    }
+
+    /**
+     * Applies a custom background {@param color} to the view identified by {@param viewId}.
+     * <p>
+     * On Android S and higher, the color is applied as a background tint, which preserves the
+     * shape (e.g. rounded corners) of the view's existing background drawable. On older versions,
+     * {@link android.view.View#setBackgroundColor(int)} is used instead, which replaces the
+     * background entirely and therefore loses any rounded corners.
+     */
+    public static void applyBackgroundColor(RemoteViews views, int viewId, @ColorInt int color) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            views.setColorStateList(viewId, "setBackgroundTintList", ColorStateList.valueOf(color));
+        } else {
+            views.setInt(viewId, "setBackgroundColor", color);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_upcoming_widget_configuration.xml
+++ b/app/src/main/res/layout/activity_upcoming_widget_configuration.xml
@@ -4,16 +4,26 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:title="@string/configure_upcoming_widget" />
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            app:title="@string/configure_upcoming_widget"
+            app:titleCentered="true" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="@dimen/spacer_7x">
+        android:layout_marginBottom="@dimen/spacer_7x"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_upcoming_widget_configuration.xml
+++ b/app/src/main/res/layout/activity_upcoming_widget_configuration.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:title="@string/configure_upcoming_widget" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/spacer_7x">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/spacer_2x">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/widget_title_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/titleEt"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:id="@+id/titleColorRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/widget_color_title" />
+
+                <ImageView
+                    android:id="@+id/titleColorSwatch"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:contentDescription="@string/widget_color_swatch"
+                    android:src="@drawable/circle_36dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widgetBackgroundRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/widget_color_widget_background" />
+
+                <ImageView
+                    android:id="@+id/widgetBackgroundSwatch"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:contentDescription="@string/widget_color_swatch"
+                    android:src="@drawable/circle_36dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/sectionTextRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/widget_color_section_text" />
+
+                <ImageView
+                    android:id="@+id/sectionTextSwatch"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:contentDescription="@string/widget_color_swatch"
+                    android:src="@drawable/circle_36dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/listBackgroundRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/widget_color_list_background" />
+
+                <ImageView
+                    android:id="@+id/listBackgroundSwatch"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:contentDescription="@string/widget_color_swatch"
+                    android:src="@drawable/circle_36dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/entryTextRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacer_2x"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/widget_color_entry_text" />
+
+                <ImageView
+                    android:id="@+id/entryTextSwatch"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:contentDescription="@string/widget_color_swatch"
+                    android:src="@drawable/circle_36dp" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:id="@+id/buttonBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:orientation="horizontal"
+        android:padding="@dimen/spacer_2x"
+        android:weightSum="1.0">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/cancel"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/spacer_1x"
+            android:layout_weight=".5"
+            android:text="@android:string/cancel"
+            android:textColor="@color/defaultBrand" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/submit"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacer_1x"
+            android:layout_weight=".5"
+            android:text="@string/simple_save"
+            app:backgroundTint="@color/defaultBrand" />
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_widget_color_picker.xml
+++ b/app/src/main/res/layout/dialog_widget_color_picker.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="?attr/dialogPreferredPadding">
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/transparentCheckbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_color_transparent"
+        android:visibility="gone" />
+
+    <it.niedermann.nextcloud.deck.ui.view.ColorChooser
+        android:id="@+id/colorChooser"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:colors="@array/board_default_colors" />
+</LinearLayout>

--- a/app/src/main/res/layout/widget_upcoming.xml
+++ b/app/src/main/res/layout/widget_upcoming.xml
@@ -2,10 +2,24 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/upcoming_widget_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_outer_background"
     android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/upcoming_widget_title_tv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/widget_inner_padding_horizontal"
+        android:paddingTop="@dimen/widget_inner_padding_vertical"
+        android:paddingEnd="@dimen/widget_inner_padding_horizontal"
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:textColor="@color/widget_foreground"
+        android:textSize="@dimen/widget_font_size_header"
+        android:textStyle="bold"
+        tools:text="@string/app_name_short" />
 
     <ListView
         android:id="@+id/upcoming_widget_lv"
@@ -14,7 +28,7 @@
         android:divider="@android:color/transparent"
         android:dividerHeight="@dimen/spacer_1x"
         android:paddingStart="@dimen/widget_inner_padding_horizontal"
-        android:paddingTop="@dimen/widget_inner_padding_vertical"
+        android:paddingTop="@dimen/spacer_1x"
         android:paddingEnd="@dimen/widget_inner_padding_horizontal"
         android:paddingBottom="@dimen/widget_inner_padding_vertical"
         tools:listitem="@layout/widget_stack_entry" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,16 @@
     <string name="simple_order">Order</string>
     <string name="edit_description">Edit description</string>
     <string name="widget_upcoming_title">Upcoming cards</string>
+    <string name="configure_upcoming_widget">Configure widget</string>
+    <string name="widget_title_hint">Widget title</string>
+    <string name="widget_color_title">Title color</string>
+    <string name="widget_color_widget_background">Widget background</string>
+    <string name="widget_color_section_text">Section text color</string>
+    <string name="widget_color_list_background">List background</string>
+    <string name="widget_color_entry_text">Entry text color</string>
+    <string name="widget_color_swatch">Selected color</string>
+    <string name="widget_color_transparent">Transparent</string>
+    <string name="widget_color_use_default">Use default</string>
     <!-- Category header for a section in the settings which contain features for advanced users -->
     <string name="simple_expert_settings">Expert settings</string>
     <string name="copy_logs">Copy logs to clipboard</string>

--- a/app/src/main/res/xml/upcoming_widget_provider.xml
+++ b/app/src/main/res/xml/upcoming_widget_provider.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_upcoming"
     android:minWidth="180dp"
     android:minHeight="110dp"
     android:minResizeWidth="80dp"
@@ -7,4 +8,5 @@
     android:previewImage="@drawable/widget_upcoming_preview"
     android:resizeMode="vertical|horizontal"
     android:updatePeriodMillis="86400000"
-    android:widgetCategory="keyguard|home_screen" />
+    android:widgetCategory="keyguard|home_screen"
+    android:configure="it.niedermann.nextcloud.deck.ui.widget.upcoming.UpcomingWidgetConfigurationActivity" />

--- a/app/src/test/java/it/niedermann/nextcloud/deck/model/widget/filter/FilterWidgetTest.java
+++ b/app/src/test/java/it/niedermann/nextcloud/deck/model/widget/filter/FilterWidgetTest.java
@@ -1,0 +1,58 @@
+package it.niedermann.nextcloud.deck.model.widget.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class FilterWidgetTest {
+
+    @Test
+    public void testAppearanceFieldsDefaultToNull() {
+        final var widget = new FilterWidget(1, EWidgetType.UPCOMING_WIDGET);
+
+        assertNull(widget.getTitleColor());
+        assertNull(widget.getWidgetBackgroundColor());
+        assertNull(widget.getSectionTextColor());
+        assertNull(widget.getListBackgroundColor());
+        assertNull(widget.getEntryTextColor());
+    }
+
+    @Test
+    public void testAppearanceFieldsGetterSetter() {
+        final var widget = new FilterWidget(1, EWidgetType.UPCOMING_WIDGET);
+
+        widget.setTitle("My Deck");
+        widget.setTitleColor(0xFF112233);
+        widget.setWidgetBackgroundColor(0x00FFFFFF);
+        widget.setSectionTextColor(0xFF445566);
+        widget.setListBackgroundColor(0x00000000);
+        widget.setEntryTextColor(0xFF778899);
+
+        assertEquals("My Deck", widget.getTitle());
+        assertEquals(Integer.valueOf(0xFF112233), widget.getTitleColor());
+        assertEquals(Integer.valueOf(0x00FFFFFF), widget.getWidgetBackgroundColor());
+        assertEquals(Integer.valueOf(0xFF445566), widget.getSectionTextColor());
+        assertEquals(Integer.valueOf(0x00000000), widget.getListBackgroundColor());
+        assertEquals(Integer.valueOf(0xFF778899), widget.getEntryTextColor());
+    }
+
+    @Test
+    public void testEqualsAndHashCodeConsiderAppearanceFields() {
+        final var widgetA = new FilterWidget(1, EWidgetType.UPCOMING_WIDGET);
+        final var widgetB = new FilterWidget(1, EWidgetType.UPCOMING_WIDGET);
+
+        assertEquals(widgetA, widgetB);
+        assertEquals(widgetA.hashCode(), widgetB.hashCode());
+
+        widgetB.setTitleColor(0xFF112233);
+
+        assertNotEquals(widgetA, widgetB);
+
+        widgetA.setTitleColor(0xFF112233);
+
+        assertEquals(widgetA, widgetB);
+        assertEquals(widgetA.hashCode(), widgetB.hashCode());
+    }
+}


### PR DESCRIPTION
# Add appearance configuration options to the Upcoming widget

Closes #1792

## Summary

Adds appearance customization to the **Upcoming** home-screen widget, inspired by the configuration options offered by the jtxBoard widget (referenced in #1792). Users can now personalize the widget instead of being stuck with the default look, which removes one of the main reasons people reached for a different app's widget alongside Deck.

The following are now configurable per widget instance, from the widget's own configuration screen:

- **Title** — custom text (defaults to "Deck") and title color
- **Widget background** — solid color or transparent
- **Section text color** (e.g. "Overdue", "Next 7 days")
- **List background** — solid color or transparent
- **Entry text color**

## Changes

- `FilterWidget`: adds `titleColor`, `widgetBackgroundColor`, `sectionTextColor`, `listBackgroundColor` and `entryTextColor` fields, persisted via a new Room migration (`Migration_35_36`, schema 35 → 36)
- `UpcomingWidgetConfigurationActivity` / `ViewModel`: new configuration screen, loading the existing config for "edit widget" or building the same default an existing widget would use ("all accounts, sorted by due date") when none exists yet
- `WidgetColorPickerDialogFragment` + `dialog_widget_color_picker.xml`: reusable color picker dialog (palette presets, custom color wheel, hex input, optional "Transparent" option) reported back via the Fragment Result API, so it can be reused across several color pickers on the same screen
- `UpcomingWidget` / `UpcomingWidgetFactory` / `WidgetUtil`: apply the configured colors when rendering the widget's `RemoteViews`, with an Android S+ tint-based path that preserves rounded corners and a fallback for older versions
- `BaseRepository`: direct (synchronous) accessors for `FilterWidget` needed by the configuration `ViewModel`
- Layout fix: wrapped the configuration screen's toolbar in an `AppBarLayout` with `fitsSystemWindows="true"` (the pattern already used elsewhere in the app, e.g. `activity_pick_stack.xml`) and centered the title — the toolbar was previously drawn under the status bar on edge-to-edge devices (this app targets SDK 37)

## Screenshots

*(attach the screenshots captured during testing: default config screen, color picker with palette/wheel/hex, a preset selected, the "Transparent" checkbox on the background rows, and the saved state with swatches updated)*
<img width="712" height="1600" alt="image" src="https://github.com/user-attachments/assets/6f588b6d-2ef1-484b-bd7b-0d061189f582" />

<img width="712" height="1600" alt="image" src="https://github.com/user-attachments/assets/92be96be-3ae4-445b-8970-91b34269d7ac" />

<img width="712" height="1600" alt="image" src="https://github.com/user-attachments/assets/969287e7-45f4-47d5-bd9f-bef6c3770b9a" />

<img width="712" height="1600" alt="image" src="https://github.com/user-attachments/assets/8f81c392-e166-4557-8a4d-074f75619e7b" />

<img width="712" height="1600" alt="image" src="https://github.com/user-attachments/assets/2c9f259a-c37b-4768-9a49-febdecf5acd7" />



## Test plan

- [x] Added unit tests for the new `FilterWidget` appearance fields (`FilterWidgetTest`)
- [x] Manually verified on an emulator (Android, API 36) by launching `UpcomingWidgetConfigurationActivity` directly via `adb` (`APPWIDGET_CONFIGURE` intent), since it doesn't require a signed-in account to load a default config
- [x] Verified each color row opens the picker, that presets/custom colors/hex input all update the swatch, and that "Transparent" is only offered for the two background rows
- [x] Verified the config screen's toolbar no longer overlaps the status bar and is centered, after the `AppBarLayout`/`fitsSystemWindows` fix