### PR TITLE
Add appearance configuration screen for the Upcoming widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -186,6 +186,13 @@
                 android:resource="@xml/upcoming_widget_provider" />
         </receiver>
 
+        <activity android:name=".ui.widget.upcoming.UpcomingWidgetConfigurationActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
         <activity android:name=".ui.widget.stack.StackWidgetConfigurationActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/DeckDatabase.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/DeckDatabase.java
@@ -69,6 +69,7 @@ import it.niedermann.nextcloud.deck.database.migration.Migration_31_32;
 import it.niedermann.nextcloud.deck.database.migration.Migration_32_33;
 import it.niedermann.nextcloud.deck.database.migration.Migration_33_34;
 import it.niedermann.nextcloud.deck.database.migration.Migration_34_35;
+import it.niedermann.nextcloud.deck.database.migration.Migration_35_36;
 import it.niedermann.nextcloud.deck.database.migration.Migration_8_9;
 import it.niedermann.nextcloud.deck.database.migration.Migration_9_10;
 import it.niedermann.nextcloud.deck.model.AccessControl;
@@ -141,7 +142,7 @@ import it.niedermann.nextcloud.deck.remote.api.LastSyncUtil;
                 FilterWidgetSort.class,
         },
         exportSchema = false,
-        version = 35
+        version = 36
 )
 @TypeConverters({DateTypeConverter.class, EnumConverter.class})
 public abstract class DeckDatabase extends RoomDatabase {
@@ -197,6 +198,7 @@ public abstract class DeckDatabase extends RoomDatabase {
                 .addMigrations(new Migration_32_33())
                 .addMigrations(new Migration_33_34())
                 .addMigrations(new Migration_34_35())
+                .addMigrations(new Migration_35_36())
                 .fallbackToDestructiveMigration()
                 .addCallback(ON_CREATE_CALLBACK)
                 .build();

--- a/app/src/main/java/it/niedermann/nextcloud/deck/database/migration/Migration_35_36.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/database/migration/Migration_35_36.java
@@ -1,0 +1,25 @@
+package it.niedermann.nextcloud.deck.database.migration;
+
+import androidx.annotation.NonNull;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+/**
+ * Adds appearance customization columns to {@code FilterWidget} (title/background/text colors),
+ * used by the widget configuration screen: https://github.com/stefan-niedermann/nextcloud-deck/issues/1792
+ */
+public class Migration_35_36 extends Migration {
+
+    public Migration_35_36() {
+        super(35, 36);
+    }
+
+    @Override
+    public void migrate(@NonNull SupportSQLiteDatabase database) {
+        database.execSQL("ALTER TABLE `FilterWidget` ADD COLUMN `titleColor` INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` ADD COLUMN `backgroundColor` INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` ADD COLUMN `headerTextColor` INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` ADD COLUMN `listBackgroundColor` INTEGER");
+        database.execSQL("ALTER TABLE `FilterWidget` ADD COLUMN `entryTextColor` INTEGER");
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/model/widget/filter/FilterWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/model/widget/filter/FilterWidget.java
@@ -27,6 +27,26 @@ public class FilterWidget {
     @NonNull
     private EWidgetType widgetType = EWidgetType.FILTER_WIDGET;
 
+    /**
+     * Appearance customization introduced for
+     * <a href="https://github.com/stefan-niedermann/nextcloud-deck/issues/1792">#1792</a>.
+     * A {@code null} value means "use the theme default" for that part of the widget.
+     */
+    @Nullable
+    private Integer titleColor;
+
+    @Nullable
+    private Integer backgroundColor;
+
+    @Nullable
+    private Integer headerTextColor;
+
+    @Nullable
+    private Integer listBackgroundColor;
+
+    @Nullable
+    private Integer entryTextColor;
+
     @Ignore
     @NonNull
     private final List<FilterWidgetAccount> accounts = new ArrayList<>();
@@ -106,6 +126,51 @@ public class FilterWidget {
         this.title = title;
     }
 
+    @Nullable
+    public Integer getTitleColor() {
+        return titleColor;
+    }
+
+    public void setTitleColor(@Nullable Integer titleColor) {
+        this.titleColor = titleColor;
+    }
+
+    @Nullable
+    public Integer getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public void setBackgroundColor(@Nullable Integer backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+
+    @Nullable
+    public Integer getHeaderTextColor() {
+        return headerTextColor;
+    }
+
+    public void setHeaderTextColor(@Nullable Integer headerTextColor) {
+        this.headerTextColor = headerTextColor;
+    }
+
+    @Nullable
+    public Integer getListBackgroundColor() {
+        return listBackgroundColor;
+    }
+
+    public void setListBackgroundColor(@Nullable Integer listBackgroundColor) {
+        this.listBackgroundColor = listBackgroundColor;
+    }
+
+    @Nullable
+    public Integer getEntryTextColor() {
+        return entryTextColor;
+    }
+
+    public void setEntryTextColor(@Nullable Integer entryTextColor) {
+        this.entryTextColor = entryTextColor;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -117,6 +182,11 @@ public class FilterWidget {
         if (!Objects.equals(title, that.title)) return false;
         if (dueType != that.dueType) return false;
         if (widgetType != that.widgetType) return false;
+        if (!Objects.equals(titleColor, that.titleColor)) return false;
+        if (!Objects.equals(backgroundColor, that.backgroundColor)) return false;
+        if (!Objects.equals(headerTextColor, that.headerTextColor)) return false;
+        if (!Objects.equals(listBackgroundColor, that.listBackgroundColor)) return false;
+        if (!Objects.equals(entryTextColor, that.entryTextColor)) return false;
         if (!accounts.equals(that.accounts)) return false;
         return sorts.equals(that.sorts);
     }
@@ -127,6 +197,11 @@ public class FilterWidget {
         result = 31 * result + (title != null ? title.hashCode() : 0);
         result = 31 * result + (dueType != null ? dueType.hashCode() : 0);
         result = 31 * result + widgetType.hashCode();
+        result = 31 * result + Objects.hashCode(titleColor);
+        result = 31 * result + Objects.hashCode(backgroundColor);
+        result = 31 * result + Objects.hashCode(headerTextColor);
+        result = 31 * result + Objects.hashCode(listBackgroundColor);
+        result = 31 * result + Objects.hashCode(entryTextColor);
         result = 31 * result + accounts.hashCode();
         result = 31 * result + sorts.hashCode();
         return result;

--- a/app/src/main/java/it/niedermann/nextcloud/deck/repository/BaseRepository.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/repository/BaseRepository.java
@@ -472,6 +472,12 @@ public class BaseRepository {
         });
     }
 
+    /**
+     * Takes {@link IResponseCallback} rather than
+     * {@link it.niedermann.nextcloud.deck.remote.api.ResponseCallback} because, unlike the
+     * stack/filter widget configuration flows, the Upcoming widget's config can span multiple
+     * accounts, so there is no single {@link Account} to attach here.
+     */
     @AnyThread
     public void updateFilterWidget(@NonNull FilterWidget filterWidget, @NonNull IResponseCallback<Boolean> callback) {
         executor.submit(() -> {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/repository/BaseRepository.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/repository/BaseRepository.java
@@ -43,7 +43,6 @@ import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
 import it.niedermann.nextcloud.deck.model.widget.filter.dto.FilterWidgetCard;
 import it.niedermann.nextcloud.deck.remote.api.IResponseCallback;
 import it.niedermann.nextcloud.deck.remote.api.LastSyncUtil;
-import it.niedermann.nextcloud.deck.remote.api.ResponseCallback;
 import it.niedermann.nextcloud.deck.remote.helpers.util.ConnectivityUtil;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsAdapterItem;
 import it.niedermann.nextcloud.deck.util.ExecutorServiceProvider;
@@ -474,7 +473,7 @@ public class BaseRepository {
     }
 
     @AnyThread
-    public void updateFilterWidget(@NonNull FilterWidget filterWidget, @NonNull ResponseCallback<Boolean> callback) {
+    public void updateFilterWidget(@NonNull FilterWidget filterWidget, @NonNull IResponseCallback<Boolean> callback) {
         executor.submit(() -> {
             try {
                 dataBaseAdapter.updateFilterWidgetDirectly(filterWidget);
@@ -494,6 +493,16 @@ public class BaseRepository {
                 callback.onError(t);
             }
         });
+    }
+
+    @WorkerThread
+    @Nullable
+    public FilterWidget getFilterWidgetDirectly(int filterWidgetId) {
+        try {
+            return dataBaseAdapter.getFilterWidgetByIdDirectly(filterWidgetId);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
     }
 
     @AnyThread

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidget.java
@@ -9,10 +9,15 @@ import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
+import android.view.View;
 import android.widget.RemoteViews;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -52,14 +57,7 @@ public class UpcomingWidget extends AppWidgetProvider {
                     DeckLog.warn(UpcomingWidget.class.getSimpleName(), "with id", appWidgetId, "already exists, perform update instead.");
                     updateAppWidget(executor, context, appWidgetManager, appWidgetIds);
                 } else {
-                    final List<Account> accountsList = baseRepository.readAccountsDirectly();
-                    final FilterWidget config = new FilterWidget(appWidgetId, EWidgetType.UPCOMING_WIDGET);
-                    config.setSorts(new FilterWidgetSort(ESortCriteria.DUE_DATE, true));
-                    config.setAccounts(accountsList.stream().map(account -> {
-                        final FilterWidgetAccount fwa = new FilterWidgetAccount(account.getId(), false);
-                        fwa.setUsers(new FilterWidgetUser(baseRepository.getUserByUidDirectly(account.getId(), account.getUserName()).getLocalId()));
-                        return fwa;
-                    }).collect(Collectors.toList()));
+                    final FilterWidget config = buildDefaultConfig(baseRepository, appWidgetId);
                     baseRepository.createFilterWidget(config, new IResponseCallback<>() {
                         @Override
                         public void onResponse(Integer response, Headers headers) {
@@ -120,9 +118,12 @@ public class UpcomingWidget extends AppWidgetProvider {
     }
 
     private static void updateAppWidget(@NonNull ExecutorService executor, @NonNull Context context, @NonNull AppWidgetManager awm, int[] appWidgetIds) {
+        final var baseRepository = new BaseRepository(context);
         for (int appWidgetId : appWidgetIds) {
             executor.submit(() -> {
                 final RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_upcoming);
+
+                applyAppearance(context, views, baseRepository.getFilterWidgetDirectly(appWidgetId));
 
                 final Intent serviceIntent = new Intent(context, UpcomingWidgetService.class);
                 serviceIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
@@ -138,6 +139,57 @@ public class UpcomingWidget extends AppWidgetProvider {
                 awm.updateAppWidget(appWidgetId, views);
             });
         }
+    }
+
+    /**
+     * Applies the user-configured title and colors (see #1792) to the widget's root layout.
+     * Only touches the root background when a custom color was actually configured, so widgets
+     * left on defaults keep the rounded-corner {@code widget_outer_background} drawable intact.
+     * Below API 31 {@link RemoteViews} cannot tint a drawable, so a custom background falls back
+     * to a plain (square-cornered) fill on those versions.
+     */
+    private static void applyAppearance(@NonNull Context context, @NonNull RemoteViews views, @Nullable FilterWidget config) {
+        final String title = config == null ? null : config.getTitle();
+        if (title != null && !title.isEmpty()) {
+            views.setTextViewText(R.id.widget_upcoming_title_tv, title);
+            views.setViewVisibility(R.id.widget_upcoming_title_tv, View.VISIBLE);
+            final Integer titleColor = config.getTitleColor();
+            if (titleColor != null) {
+                views.setTextColor(R.id.widget_upcoming_title_tv, titleColor);
+            }
+        } else {
+            views.setViewVisibility(R.id.widget_upcoming_title_tv, View.GONE);
+        }
+
+        final Integer backgroundColor = config == null ? null : config.getBackgroundColor();
+        if (backgroundColor != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                views.setColorStateList(R.id.widget_upcoming_root, "setBackgroundTintList", ColorStateList.valueOf(backgroundColor));
+            } else {
+                views.setInt(R.id.widget_upcoming_root, "setBackgroundColor", backgroundColor);
+            }
+        }
+
+        final Integer listBackgroundColor = config == null ? null : config.getListBackgroundColor();
+        views.setInt(R.id.upcoming_widget_lv, "setBackgroundColor", listBackgroundColor != null ? listBackgroundColor : Color.TRANSPARENT);
+    }
+
+    /**
+     * Builds the default configuration for a newly added Upcoming widget: due-date sorted,
+     * spanning all currently known accounts. Shared between the auto-add fallback in
+     * {@link #onUpdate} and {@link UpcomingWidgetConfigurationActivity}.
+     */
+    @NonNull
+    static FilterWidget buildDefaultConfig(@NonNull BaseRepository baseRepository, int appWidgetId) {
+        final List<Account> accountsList = baseRepository.readAccountsDirectly();
+        final FilterWidget config = new FilterWidget(appWidgetId, EWidgetType.UPCOMING_WIDGET);
+        config.setSorts(new FilterWidgetSort(ESortCriteria.DUE_DATE, true));
+        config.setAccounts(accountsList.stream().map(account -> {
+            final FilterWidgetAccount fwa = new FilterWidgetAccount(account.getId(), false);
+            fwa.setUsers(new FilterWidgetUser(baseRepository.getUserByUidDirectly(account.getId(), account.getUserName()).getLocalId()));
+            return fwa;
+        }).collect(Collectors.toList()));
+        return config;
     }
 
     static Intent fillEditPendingIntent(long accountId, long localCardId) {

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationActivity.java
@@ -127,6 +127,9 @@ public class UpcomingWidgetConfigurationActivity extends AppCompatActivity {
     }
 
     private void updateSwatch(@NonNull ImageView swatch, @ColorInt int color) {
+        // circle_36dp is a plain filled circle, i.e. an actual color preview. Don't swap this for
+        // circle_alpha_check_36dp: that drawable is ColorChooser's own "currently selected"
+        // checkmark overlay, not a general-purpose swatch, and tinting it fully hides the check.
         swatch.setImageDrawable(DeckViewThemeUtils.getTintedImageView(this, R.drawable.circle_36dp, color));
     }
 

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationActivity.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetConfigurationActivity.java
@@ -1,0 +1,221 @@
+package it.niedermann.nextcloud.deck.ui.widget.upcoming;
+
+import android.appwidget.AppWidgetManager;
+import android.content.Intent;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.widget.ImageView;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import it.niedermann.nextcloud.deck.DeckLog;
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.databinding.ActivityUpcomingWidgetConfigurationBinding;
+import it.niedermann.nextcloud.deck.databinding.RowWidgetAppearanceColorBinding;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
+import it.niedermann.nextcloud.deck.repository.BaseRepository;
+import it.niedermann.nextcloud.deck.ui.theme.DeckViewThemeUtils;
+
+/**
+ * Lets the user customize the appearance of an {@link UpcomingWidget} instance: title,
+ * title/background/section-header/list/entry colors.
+ *
+ * @see <a href="https://github.com/stefan-niedermann/nextcloud-deck/issues/1792">#1792</a>
+ */
+public class UpcomingWidgetConfigurationActivity extends AppCompatActivity {
+
+    private int appWidgetId;
+    private ActivityUpcomingWidgetConfigurationBinding binding;
+    private BaseRepository baseRepository;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Nullable
+    private Integer titleColor;
+    @Nullable
+    private Integer backgroundColor;
+    @Nullable
+    private Integer headerTextColor;
+    @Nullable
+    private Integer listBackgroundColor;
+    @Nullable
+    private Integer entryTextColor;
+
+    private List<ColorOption> colorOptions;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        binding = ActivityUpcomingWidgetConfigurationBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+        setSupportActionBar(binding.toolbar);
+
+        setResult(RESULT_CANCELED);
+        final Bundle extras = getIntent().getExtras();
+        appWidgetId = extras == null
+                ? AppWidgetManager.INVALID_APPWIDGET_ID
+                : extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID);
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            DeckLog.error("INVALID_APPWIDGET_ID");
+            finish();
+            return;
+        }
+
+        baseRepository = new BaseRepository(this);
+
+        colorOptions = List.of(
+                new ColorOption("title_color", binding.titleColorRow, R.string.widget_appearance_title_color,
+                        ContextCompat.getColor(this, R.color.widget_foreground),
+                        () -> titleColor, color -> titleColor = color),
+                new ColorOption("background_color", binding.backgroundColorRow, R.string.widget_appearance_background_color,
+                        ContextCompat.getColor(this, R.color.widget_outer_background),
+                        () -> backgroundColor, color -> backgroundColor = color),
+                new ColorOption("header_text_color", binding.headerTextColorRow, R.string.widget_appearance_header_text_color,
+                        ContextCompat.getColor(this, R.color.widget_foreground),
+                        () -> headerTextColor, color -> headerTextColor = color),
+                new ColorOption("list_background_color", binding.listBackgroundColorRow, R.string.widget_appearance_list_background_color,
+                        Color.TRANSPARENT,
+                        () -> listBackgroundColor, color -> listBackgroundColor = color),
+                new ColorOption("entry_text_color", binding.entryTextColorRow, R.string.widget_appearance_entry_text_color,
+                        ContextCompat.getColor(this, R.color.widget_foreground),
+                        () -> entryTextColor, color -> entryTextColor = color)
+        );
+
+        for (final var option : colorOptions) {
+            bindColorRow(option);
+        }
+
+        binding.cancel.setOnClickListener(v -> finish());
+        binding.submit.setOnClickListener(v -> save());
+
+        loadExistingConfig();
+    }
+
+    private void bindColorRow(@NonNull ColorOption option) {
+        option.row.label.setText(option.labelRes);
+        updateSwatch(option.row.swatch, option.currentOrDefault());
+        option.row.getRoot().setOnClickListener(v -> {
+            getSupportFragmentManager().setFragmentResultListener(option.requestKey, this, (key, bundle) -> {
+                if (bundle.getBoolean(WidgetColorPickerDialogFragment.BUNDLE_KEY_USE_DEFAULT, false)) {
+                    option.setter.accept(null);
+                } else if (bundle.containsKey(WidgetColorPickerDialogFragment.BUNDLE_KEY_COLOR)) {
+                    option.setter.accept(bundle.getInt(WidgetColorPickerDialogFragment.BUNDLE_KEY_COLOR));
+                }
+                updateSwatch(option.row.swatch, option.currentOrDefault());
+            });
+            WidgetColorPickerDialogFragment.newInstance(option.requestKey, option.currentOrDefault())
+                    .show(getSupportFragmentManager(), option.requestKey);
+        });
+    }
+
+    private void refreshSwatches() {
+        for (final var option : colorOptions) {
+            updateSwatch(option.row.swatch, option.currentOrDefault());
+        }
+    }
+
+    private void updateSwatch(@NonNull ImageView swatch, @ColorInt int color) {
+        swatch.setImageDrawable(DeckViewThemeUtils.getTintedImageView(this, R.drawable.circle_36dp, color));
+    }
+
+    private void loadExistingConfig() {
+        executor.execute(() -> {
+            final FilterWidget existing = baseRepository.getFilterWidgetDirectly(appWidgetId);
+            if (existing == null) {
+                return;
+            }
+            runOnUiThread(() -> {
+                binding.titleEt.setText(existing.getTitle());
+                titleColor = existing.getTitleColor();
+                backgroundColor = existing.getBackgroundColor();
+                headerTextColor = existing.getHeaderTextColor();
+                listBackgroundColor = existing.getListBackgroundColor();
+                entryTextColor = existing.getEntryTextColor();
+                refreshSwatches();
+            });
+        });
+    }
+
+    private void save() {
+        final String title = binding.titleEt.getText() == null ? null : binding.titleEt.getText().toString().trim();
+        binding.submit.setEnabled(false);
+
+        executor.execute(() -> {
+            FilterWidget config = baseRepository.getFilterWidgetDirectly(appWidgetId);
+            final boolean isNew = config == null;
+            if (isNew) {
+                config = UpcomingWidget.buildDefaultConfig(baseRepository, appWidgetId);
+            }
+
+            config.setTitle(title == null || title.isEmpty() ? null : title);
+            config.setTitleColor(titleColor);
+            config.setBackgroundColor(backgroundColor);
+            config.setHeaderTextColor(headerTextColor);
+            config.setListBackgroundColor(listBackgroundColor);
+            config.setEntryTextColor(entryTextColor);
+
+            if (isNew) {
+                baseRepository.createFilterWidget(config, (response, headers) -> runOnUiThread(this::finishSuccessfully));
+            } else {
+                baseRepository.updateFilterWidget(config, (response, headers) -> runOnUiThread(this::finishSuccessfully));
+            }
+        });
+    }
+
+    private void finishSuccessfully() {
+        final Intent updateIntent = new Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE, null, getApplicationContext(), UpcomingWidget.class)
+                .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+        setResult(RESULT_OK, updateIntent);
+        getApplicationContext().sendBroadcast(updateIntent);
+        finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        binding = null;
+    }
+
+    private static final class ColorOption {
+        @NonNull
+        private final String requestKey;
+        @NonNull
+        private final RowWidgetAppearanceColorBinding row;
+        @StringRes
+        private final int labelRes;
+        @ColorInt
+        private final int defaultColor;
+        @NonNull
+        private final Supplier<Integer> getter;
+        @NonNull
+        private final Consumer<Integer> setter;
+
+        private ColorOption(@NonNull String requestKey, @NonNull RowWidgetAppearanceColorBinding row, @StringRes int labelRes,
+                             @ColorInt int defaultColor, @NonNull Supplier<Integer> getter, @NonNull Consumer<Integer> setter) {
+            this.requestKey = requestKey;
+            this.row = row;
+            this.labelRes = labelRes;
+            this.defaultColor = defaultColor;
+            this.getter = getter;
+            this.setter = setter;
+        }
+
+        @ColorInt
+        private int currentOrDefault() {
+            final Integer current = getter.get();
+            return current == null ? defaultColor : current;
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/UpcomingWidgetFactory.java
@@ -7,6 +7,7 @@ import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.NoSuchElementException;
 import it.niedermann.nextcloud.deck.DeckLog;
 import it.niedermann.nextcloud.deck.R;
 import it.niedermann.nextcloud.deck.model.full.FullCard;
+import it.niedermann.nextcloud.deck.model.widget.filter.FilterWidget;
 import it.niedermann.nextcloud.deck.repository.BaseRepository;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsAdapterItem;
 import it.niedermann.nextcloud.deck.ui.upcomingcards.UpcomingCardsAdapterSectionItem;
@@ -29,6 +31,9 @@ public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFact
 
     @NonNull
     private final List<Object> data = new ArrayList<>();
+
+    @Nullable
+    private FilterWidget config;
 
     UpcomingWidgetFactory(@NonNull Context context, Intent intent) {
         this.context = context;
@@ -47,6 +52,7 @@ public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFact
 
     @Override
     public void onDataSetChanged() {
+        config = baseRepository.getFilterWidgetDirectly(appWidgetId);
         try {
             final List<UpcomingCardsAdapterItem> response = baseRepository.getCardsForUpcomingCardsForWidget();
             DeckLog.verbose(UpcomingWidgetFactory.class.getSimpleName(), "with id", appWidgetId, "fetched", response.size(), "cards from the database.");
@@ -84,11 +90,17 @@ public class UpcomingWidgetFactory implements RemoteViewsService.RemoteViewsFact
             } else {
                 widget_entry.setViewPadding(R.id.widget_entry_content_tv, headerHorizontalPadding, headerVerticalPaddingNth, headerHorizontalPadding, 0);
             }
+            if (config != null && config.getHeaderTextColor() != null) {
+                widget_entry.setTextColor(R.id.widget_entry_content_tv, config.getHeaderTextColor());
+            }
             widget_entry.setOnClickFillInIntent(R.id.widget_stack_entry, UpcomingWidget.fillOpenPendingIntent());
         } else if (data.get(i).getClass() == UpcomingCardsAdapterItem.class || data.get(i) instanceof UpcomingCardsAdapterItem) {
             final FullCard card = ((UpcomingCardsAdapterItem) data.get(i)).getFullCard();
             widget_entry = new RemoteViews(context.getPackageName(), R.layout.widget_stack_entry);
             widget_entry.setTextViewText(R.id.widget_entry_content_tv, card.getCard().getTitle());
+            if (config != null && config.getEntryTextColor() != null) {
+                widget_entry.setTextColor(R.id.widget_entry_content_tv, config.getEntryTextColor());
+            }
             widget_entry.setOnClickFillInIntent(R.id.widget_stack_entry, UpcomingWidget.fillEditPendingIntent(card.getAccountId(), card.getLocalId()));
         } else {
             DeckLog.logError(new IllegalStateException("Expected items to be instance of " + UpcomingCardsAdapterSectionItem.class.getSimpleName() + " or " + UpcomingCardsAdapterItem.class.getSimpleName()));

--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/WidgetColorPickerDialogFragment.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/widget/upcoming/WidgetColorPickerDialogFragment.java
@@ -1,0 +1,71 @@
+package it.niedermann.nextcloud.deck.ui.widget.upcoming;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import it.niedermann.nextcloud.deck.R;
+import it.niedermann.nextcloud.deck.databinding.DialogWidgetColorPickerBinding;
+
+/**
+ * Reusable color picker dialog for the widget appearance configuration screen.
+ * Reports the chosen color (or "use default") back to the caller via the Fragment Result API.
+ */
+public class WidgetColorPickerDialogFragment extends DialogFragment {
+
+    public static final String BUNDLE_KEY_COLOR = "color";
+    public static final String BUNDLE_KEY_USE_DEFAULT = "use_default";
+
+    private static final String ARG_REQUEST_KEY = "request_key";
+    private static final String ARG_INITIAL_COLOR = "initial_color";
+
+    private DialogWidgetColorPickerBinding binding;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        binding = DialogWidgetColorPickerBinding.inflate(requireActivity().getLayoutInflater());
+
+        final var args = requireArguments();
+        final String requestKey = args.getString(ARG_REQUEST_KEY);
+        final int initialColor = args.getInt(ARG_INITIAL_COLOR);
+        binding.colorChooser.selectColor(initialColor);
+
+        return new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.choose_color)
+                .setView(binding.getRoot())
+                .setPositiveButton(R.string.simple_save, (dialog, which) -> {
+                    final var result = new Bundle();
+                    result.putInt(BUNDLE_KEY_COLOR, binding.colorChooser.getSelectedColor());
+                    getParentFragmentManager().setFragmentResult(requestKey, result);
+                })
+                .setNegativeButton(R.string.widget_appearance_use_default, (dialog, which) -> {
+                    final var result = new Bundle();
+                    result.putBoolean(BUNDLE_KEY_USE_DEFAULT, true);
+                    getParentFragmentManager().setFragmentResult(requestKey, result);
+                })
+                .setNeutralButton(android.R.string.cancel, null)
+                .create();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
+    public static WidgetColorPickerDialogFragment newInstance(@NonNull String requestKey, @ColorInt int initialColor) {
+        final var fragment = new WidgetColorPickerDialogFragment();
+        final var args = new Bundle();
+        args.putString(ARG_REQUEST_KEY, requestKey);
+        args.putInt(ARG_INITIAL_COLOR, initialColor);
+        fragment.setArguments(args);
+        return fragment;
+    }
+}

--- a/app/src/main/res/layout/activity_upcoming_widget_configuration.xml
+++ b/app/src/main/res/layout/activity_upcoming_widget_configuration.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:showIn="@layout/activity_upcoming_widget_configuration">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            app:title="@string/widget_appearance_configure_title" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="72dp"
+        android:clipToPadding="false"
+        android:paddingHorizontal="@dimen/spacer_2x"
+        android:paddingVertical="@dimen/spacer_2x"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/titleInputLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/widget_appearance_title_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/titleEt"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <include
+                android:id="@+id/titleColorRow"
+                layout="@layout/row_widget_appearance_color"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacer_2x" />
+
+            <include
+                android:id="@+id/backgroundColorRow"
+                layout="@layout/row_widget_appearance_color"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/headerTextColorRow"
+                layout="@layout/row_widget_appearance_color"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/listBackgroundColorRow"
+                layout="@layout/row_widget_appearance_color"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/entryTextColorRow"
+                layout="@layout/row_widget_appearance_color"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/buttonBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:orientation="horizontal"
+        android:padding="@dimen/spacer_2x"
+        android:weightSum="1.0">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/cancel"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/spacer_1x"
+            android:layout_weight=".5"
+            android:text="@android:string/cancel"
+            android:textColor="@color/defaultBrand" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/submit"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacer_1x"
+            android:layout_weight=".5"
+            android:text="@string/simple_save"
+            app:backgroundTint="@color/defaultBrand" />
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_widget_color_picker.xml
+++ b/app/src/main/res/layout/dialog_widget_color_picker.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="?attr/dialogPreferredPadding">
+
+    <it.niedermann.nextcloud.deck.ui.view.ColorChooser
+        android:id="@+id/colorChooser"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:colors="@array/widget_appearance_colors" />
+</LinearLayout>

--- a/app/src/main/res/layout/row_widget_appearance_color.xml
+++ b/app/src/main/res/layout/row_widget_appearance_color.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingVertical="@dimen/spacer_1x">
+
+    <TextView
+        android:id="@+id/label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?attr/textAppearanceBody1"
+        tools:text="@string/widget_appearance_title_color" />
+
+    <ImageView
+        android:id="@+id/swatch"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:contentDescription="@string/choose_color"
+        android:src="@drawable/circle_36dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/widget_upcoming.xml
+++ b/app/src/main/res/layout/widget_upcoming.xml
@@ -2,10 +2,26 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_upcoming_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_outer_background"
     android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/widget_upcoming_title_tv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/widget_inner_padding_horizontal"
+        android:paddingTop="@dimen/widget_inner_padding_vertical"
+        android:paddingEnd="@dimen/widget_inner_padding_horizontal"
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:textColor="@color/widget_foreground"
+        android:textSize="@dimen/widget_font_size_header"
+        android:textStyle="bold"
+        android:visibility="gone"
+        tools:text="@string/app_name"
+        tools:visibility="visible" />
 
     <ListView
         android:id="@+id/upcoming_widget_lv"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -48,6 +48,24 @@
     <color name="widget_background">#ddffffff</color>
     <color name="widget_foreground">#222222</color>
 
+    <!-- Swatches offered in the widget appearance configuration screen, see #1792 -->
+    <string-array name="widget_appearance_colors">
+        <item>#00000000</item>
+        <item>#ffffffff</item>
+        <item>#ff222222</item>
+        <item>#ffb6469d</item>
+        <item>#ffbf678b</item>
+        <item>#ffc98879</item>
+        <item>#ffddcb55</item>
+        <item>#ffa5b872</item>
+        <item>#ff6ea68f</item>
+        <item>#ff3794ac</item>
+        <item>#ff0082c9</item>
+        <item>#ff2d73be</item>
+        <item>#ff5b64b3</item>
+        <item>#ff8855a8</item>
+    </string-array>
+
     <!-- ======================================= -->
     <!-- Static colors                           -->
     <!-- Are theme independent and should match  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,4 +369,14 @@
     <string name="label_color">Color</string>
     <string name="label_clear_color">Clear color</string>
     <string name="choose_color">Choose color</string>
+
+    <!-- Widget appearance configuration, see https://github.com/stefan-niedermann/nextcloud-deck/issues/1792 -->
+    <string name="widget_appearance_configure_title">Configure widget appearance</string>
+    <string name="widget_appearance_title_hint">Widget title</string>
+    <string name="widget_appearance_title_color">Title text color</string>
+    <string name="widget_appearance_background_color">Widget background color</string>
+    <string name="widget_appearance_header_text_color">Section header text color</string>
+    <string name="widget_appearance_list_background_color">Task list background color</string>
+    <string name="widget_appearance_entry_text_color">Task text color</string>
+    <string name="widget_appearance_use_default">Use default</string>
 </resources>

--- a/app/src/main/res/xml/upcoming_widget_provider.xml
+++ b/app/src/main/res/xml/upcoming_widget_provider.xml
@@ -7,4 +7,5 @@
     android:previewImage="@drawable/widget_upcoming_preview"
     android:resizeMode="vertical|horizontal"
     android:updatePeriodMillis="86400000"
-    android:widgetCategory="keyguard|home_screen" />
+    android:widgetCategory="keyguard|home_screen"
+    android:configure="it.niedermann.nextcloud.deck.ui.widget.upcoming.UpcomingWidgetConfigurationActivity" />


### PR DESCRIPTION
## Summary

Closes part of #1792 by adding an appearance configuration screen for the **Upcoming** widget (the one shown in the issue's screenshots — "Vencidos" / "Próximos 7 dias").

Lets the user customize, per widget instance:
- Widget title text (optional) and its text color
- Widget background color
- Section header text color
- Task list background color
- Task entry text color

All color pickers reuse the existing `ColorChooser` component (already used for label colors), extended with a dedicated swatch palette that includes a transparent option.

## What changed

- **`FilterWidget`** (the entity already backing this widget's config) gains 5 new nullable color fields; `null` means "use the theme default". Persisted via a new Room migration (`Migration_35_36`, DB v35→36).
- **`UpcomingWidgetConfigurationActivity`** (new): the widget previously had *no* configuration step at all — it was auto-added with default settings. `android:configure` is now wired up in `upcoming_widget_provider.xml`, so adding the widget opens this screen first, same UX pattern as the existing Stack/Filter widget configuration activities.
- **`UpcomingWidget` / `UpcomingWidgetFactory`**: apply the stored colors when building the `RemoteViews`. On API 31+, the widget background is applied via `setBackgroundTintList` so the existing rounded-corner shape drawable is preserved; below API 31 it falls back to a flat `setBackgroundColor` fill (RemoteViews can't tint a drawable pre-31). This only kicks in when a custom color is actually set — widgets left on defaults are untouched.
- `BaseRepository#updateFilterWidget` callback type widened from `ResponseCallback<Boolean>` (requires a single `Account`) to `IResponseCallback<Boolean>`, since the Upcoming widget can span multiple accounts and there's no single "the" account to attach.

## Scope

Intentionally scoped to the **Upcoming** widget only, matching the widget in the issue's screenshots. Stack/Filter widgets are untouched — happy to extend to those in a follow-up if that's wanted.

## Testing

Manually verified on a Pixel 7 emulator (API 37):
- Fresh install + existing-install DB migration, no crashes.
- Added the widget through the real "drag from picker" flow → configuration screen opens automatically.
- Set a title and custom colors, saved, reopened the config screen → values persisted correctly.
- The actual home screen widget renders with the custom title and background color, rounded corners intact.

## Screenshots

**1. Configuration screen, opened automatically when adding the widget**
![Configuration screen, default state](https://raw.githubusercontent.com/cyberchristian92/nextcloud-deck/pr-1906-screenshots/1-config-screen-default.png)

**2. Color picker for each option, with a custom color wheel**
![Color picker dialog](https://raw.githubusercontent.com/cyberchristian92/nextcloud-deck/pr-1906-screenshots/2-color-picker-dialog.png)

**3. Title and background color set**
![Configuration screen with title and background color set](https://raw.githubusercontent.com/cyberchristian92/nextcloud-deck/pr-1906-screenshots/3-config-screen-filled.png)

**4. The widget rendered on the home screen with the custom title and background**
![Widget on the home screen with custom title and background color](https://raw.githubusercontent.com/cyberchristian92/nextcloud-deck/pr-1906-screenshots/4-widget-on-home-screen.png)

## Known limitations

- The "transparent" and white swatches in the color picker dialog are hard to see against the dialog's own white background (they're not invisible — tap targets still work, and the checkmark shows once selected — but visually you have to look closely). This comes from reusing `ColorChooser` as-is; fixing it properly would mean adding a checkered/alpha-aware background behind the swatch grid, which felt like scope creep for this PR. Happy to add it if it's a blocker.
- Below Android 12 (API 31), a custom widget background color replaces the rounded-corner shape with a flat rectangle, since `RemoteViews` can't tint a drawable pre-31. Documented inline in `UpcomingWidget#applyAppearance`.

## Open questions / feedback welcome

- Any preference on how "reset to default" should behave — currently each color dialog has a "Use default" button.
- Whether extending this to Stack/Filter widgets in the same PR (vs. a follow-up) is preferred.

This is a draft while I get feedback on the approach before polishing further.

