### PR TITLE
Show a readable error when an attachment hits the server size limit #830

### DIFF
--- a/app/src/main/java/it/niedermann/nextcloud/deck/ui/exception/tips/TipsAdapter.java
+++ b/app/src/main/java/it/niedermann/nextcloud/deck/ui/exception/tips/TipsAdapter.java
@@ -107,28 +107,36 @@ public class TipsAdapter extends RecyclerView.Adapter<TipsViewHolder> {
         } else if (throwable instanceof JSONException || throwable instanceof NullPointerException) {
             add(R.string.error_dialog_check_server);
         } else if (throwable instanceof NextcloudHttpRequestFailedException) {
-            int statusCode = ((NextcloudHttpRequestFailedException) throwable).getStatusCode();
-            switch (statusCode) {
-                case 302 -> add(R.string.error_dialog_redirect);
-                case 500 -> {
-                    if (account != null) {
-                        add(R.string.error_dialog_check_server_logs, new Intent(Intent.ACTION_VIEW)
-                                .putExtra(INTENT_EXTRA_BUTTON_TEXT, R.string.error_action_server_logs)
-                                .setData(Uri.parse(account.getUrl() + context.getString(R.string.url_fragment_server_logs))));
-                    } else {
-                        add(R.string.error_dialog_check_server_logs);
+            if (isAttachmentFileTooLarge(throwable)) {
+                add(R.string.error_dialog_attachment_file_too_large);
+            } else {
+                int statusCode = ((NextcloudHttpRequestFailedException) throwable).getStatusCode();
+                switch (statusCode) {
+                    case 302 -> add(R.string.error_dialog_redirect);
+                    case 500 -> {
+                        if (account != null) {
+                            add(R.string.error_dialog_check_server_logs, new Intent(Intent.ACTION_VIEW)
+                                    .putExtra(INTENT_EXTRA_BUTTON_TEXT, R.string.error_action_server_logs)
+                                    .setData(Uri.parse(account.getUrl() + context.getString(R.string.url_fragment_server_logs))));
+                        } else {
+                            add(R.string.error_dialog_check_server_logs);
+                        }
                     }
+                    case 503 -> add(R.string.error_dialog_check_maintenance);
+                    case 507 -> add(R.string.error_dialog_insufficient_storage);
+                    case 900 -> add(R.string.error_dialog_tip_parsing_failed);
                 }
-                case 503 -> add(R.string.error_dialog_check_maintenance);
-                case 507 -> add(R.string.error_dialog_insufficient_storage);
-                case 900 -> add(R.string.error_dialog_tip_parsing_failed);
-            }
-            if ((statusCode >= 400 && statusCode < 500) || statusCode == 900) {
-                add(R.string.error_dialog_tip_clear_storage_might_help);
-                add(R.string.error_dialog_tip_clear_storage, INTENT_APP_INFO);
+                if ((statusCode >= 400 && statusCode < 500) || statusCode == 900) {
+                    add(R.string.error_dialog_tip_clear_storage_might_help);
+                    add(R.string.error_dialog_tip_clear_storage, INTENT_APP_INFO);
+                }
             }
         } else if (throwable instanceof UploadAttachmentFailedException) {
-            add(R.string.error_dialog_attachment_upload_failed);
+            if (isAttachmentFileTooLarge(throwable)) {
+                add(R.string.error_dialog_attachment_file_too_large);
+            } else {
+                add(R.string.error_dialog_attachment_upload_failed);
+            }
         } else if (throwable instanceof ClassNotFoundException) {
             final Throwable cause = throwable.getCause();
             if (cause != null) {
@@ -197,6 +205,25 @@ public class TipsAdapter extends RecyclerView.Adapter<TipsViewHolder> {
     public void add(@StringRes int text, @Nullable Intent primaryAction) {
         tips.add(new TipsModel(text, primaryAction));
         notifyItemInserted(tips.size());
+    }
+
+    static boolean isAttachmentFileTooLarge(@NonNull Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof NextcloudHttpRequestFailedException http && http.getStatusCode() == 413) {
+                return true;
+            }
+            final String message = current.getMessage();
+            if (message != null) {
+                final String lower = message.toLowerCase();
+                if (lower.contains("file size exceeds") || lower.contains("max file size")) {
+                    return true;
+                }
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+        }
+        return false;
     }
 
     private Optional<Intent> getOpenFilesIntent(@NonNull Context context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,6 +261,7 @@
     <string name="error_dialog_user_not_found_in_database">The current user does not match the user we have in our database. If you are using LDAP on your Nextcloud instance, your Nextcloud app might have stored an old user ID.</string>
     <string name="error_dialog_capabilities_not_parsable">We could not fetch the capabilities of your server. Please make sure your server is running well and other client apps are able to access Nextcloud.</string>
     <string name="error_dialog_attachment_upload_failed">An attachment could not be uploaded. Please try to share it on another way and let us know about this bug.</string>
+    <string name="error_dialog_attachment_file_too_large">The attachment is larger than this server's upload size limit. Try a smaller file or ask your admin to raise the limit.</string>
     <string name="error_dialog_certificate">Something seems to be wrong with the certificate of the server. Please check all the accounts in the Nextcloud app for further information.</string>
     <string name="error_dialog_tip_disable_battery_optimizations">Please disable all battery optimizations for Nextcloud and the Deck app.</string>
     <string name="error_dialog_unknown_error">Your Nextcloud instance seems to be not reachable. Please check your internet connection and whether you are able to connect to your instance via browser.</string>

--- a/app/src/test/java/it/niedermann/nextcloud/deck/ui/exception/tips/TipsAdapterFileTooLargeTest.java
+++ b/app/src/test/java/it/niedermann/nextcloud/deck/ui/exception/tips/TipsAdapterFileTooLargeTest.java
@@ -1,0 +1,26 @@
+package it.niedermann.nextcloud.deck.ui.exception.tips;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import it.niedermann.nextcloud.deck.exceptions.UploadAttachmentFailedException;
+
+public class TipsAdapterFileTooLargeTest {
+
+    @Test
+    public void detectsServerFileSizeLimitMessage() {
+        final Throwable throwable = new UploadAttachmentFailedException(
+                "Unknown URI scheme",
+                new IllegalStateException("{\"status\":500,\"message\":\"No file uploaded or file size exceeds maximum of 2 MB\"}")
+        );
+        assertTrue(TipsAdapter.isAttachmentFileTooLarge(throwable));
+    }
+
+    @Test
+    public void ignoresUnknownUriSchemeWithoutSizeLimit() {
+        assertFalse(TipsAdapter.isAttachmentFileTooLarge(
+                new UploadAttachmentFailedException("Unknown URI scheme: content")));
+    }
+}


### PR DESCRIPTION
The server answers with HTTP 500 and \"file size exceeds maximum\". That used to land as a generic upload failure.

I walk the cause chain in TipsAdapter (and HTTP 413) and show a hint to try a smaller file.

Fixes #830